### PR TITLE
Added remove_order DB persistence, made view_orders send the svg when it finishes

### DIFF
--- a/bot/command.py
+++ b/bot/command.py
@@ -55,19 +55,19 @@ def remove_order(ctx: commands.Context, manager: Manager) -> tuple[str, str | No
     if is_gm(ctx.message.author):
         if not is_gm_channel(ctx.channel):
             raise PermissionError("You cannot remove orders as a GM in a non-GM channel.")
-        return parse_remove_order(ctx.message.content, None, board), None
+        return parse_remove_order(ctx.message.content, None, board, ctx.guild.id), None
 
     player = get_player_by_role(ctx.message.author, manager, ctx.guild.id)
     if player is not None:
         if not is_player_channel(player.name, ctx.channel):
             raise PermissionError("You cannot remove orders as a player outside of your orders channel.")
-        return parse_remove_order(ctx.message.content, player, board), None
+        return parse_remove_order(ctx.message.content, player, board, ctx.guild.id), None
 
     raise PermissionError("You cannot remove orders because you are neither a GM nor a player.")
 
 
 # TODO: (!) output orders map BUT create something like .orders_log to see it in text like it is here
-def view_orders(ctx: commands.Context, manager: Manager) -> tuple[str, str]:
+def view_orders(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     if is_gm(ctx.message.author):
         if not is_gm_channel(ctx.channel):
             raise PermissionError("You cannot view orders as a GM in a non-GM channel.")
@@ -78,8 +78,8 @@ def view_orders(ctx: commands.Context, manager: Manager) -> tuple[str, str]:
     if player is not None:
         if not is_player_channel(player.name, ctx.channel):
             raise PermissionError("You cannot view orders as a player outside of your orders channel.")
-        file_name = manager.draw_moves_map(ctx.guild.id, player)
-        return get_orders(manager.get_board(ctx.guild.id), player), file_name
+        # file_name = manager.draw_moves_map(ctx.guild.id, player)
+        return get_orders(manager.get_board(ctx.guild.id), player), None
 
     raise PermissionError("You cannot view orders because you are neither a GM nor a player.")
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -17,7 +17,7 @@ ping_text_choices = [
 ]
 
 
-def ping(ctx: commands.Context, _: Manager) -> str:
+def ping(ctx: commands.Context, _: Manager) -> tuple[str, str | None]:
     response = "Beep Boop"
     if random.random() < 0.1:
         author = ctx.message.author
@@ -28,63 +28,63 @@ def ping(ctx: commands.Context, _: Manager) -> str:
         if not name:
             name = author.name
         response = name + " " + random.choice(ping_text_choices) + content
-    return response
+    return response, None
 
 
 # TODO: (DB) warning cron when in cloud
-def order(ctx: commands.Context, manager: Manager) -> str:
+def order(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     board = manager.get_board(ctx.guild.id)
 
     if is_gm(ctx.message.author):
         if not is_gm_channel(ctx.channel):
             raise PermissionError("You cannot order as a GM in a non-GM channel.")
-        return parse_order(ctx.message.content, None, board, ctx.guild.id)
+        return parse_order(ctx.message.content, None, board, ctx.guild.id), None
 
     player = get_player_by_role(ctx.message.author, manager, ctx.guild.id)
     if player is not None:
         if not is_player_channel(player.name, ctx.channel):
             raise PermissionError("You cannot order as a player outside of your orders channel.")
-        return parse_order(ctx.message.content, player, board, ctx.guild.id)
+        return parse_order(ctx.message.content, player, board, ctx.guild.id), None
 
     raise PermissionError("You cannot order units because you are neither a GM nor a player.")
 
 
-def remove_order(ctx: commands.Context, manager: Manager) -> str:
+def remove_order(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     board = manager.get_board(ctx.guild.id)
 
     if is_gm(ctx.message.author):
         if not is_gm_channel(ctx.channel):
             raise PermissionError("You cannot remove orders as a GM in a non-GM channel.")
-        return parse_remove_order(ctx.message.content, None, board)
+        return parse_remove_order(ctx.message.content, None, board), None
 
     player = get_player_by_role(ctx.message.author, manager, ctx.guild.id)
     if player is not None:
         if not is_player_channel(player.name, ctx.channel):
             raise PermissionError("You cannot remove orders as a player outside of your orders channel.")
-        return parse_remove_order(ctx.message.content, player, board)
+        return parse_remove_order(ctx.message.content, player, board), None
 
     raise PermissionError("You cannot remove orders because you are neither a GM nor a player.")
 
 
 # TODO: (!) output orders map BUT create something like .orders_log to see it in text like it is here
-def view_orders(ctx: commands.Context, manager: Manager) -> str:
+def view_orders(ctx: commands.Context, manager: Manager) -> tuple[str, str]:
     if is_gm(ctx.message.author):
         if not is_gm_channel(ctx.channel):
             raise PermissionError("You cannot view orders as a GM in a non-GM channel.")
-        return get_orders(manager.get_board(ctx.guild.id), None)
-        # return manager.draw_moves_map(ctx.guild.id, None)
+        file_name = manager.draw_moves_map(ctx.guild.id, None)
+        return get_orders(manager.get_board(ctx.guild.id), None), file_name
 
     player = get_player_by_role(ctx.message.author, manager, ctx.guild.id)
     if player is not None:
         if not is_player_channel(player.name, ctx.channel):
             raise PermissionError("You cannot view orders as a player outside of your orders channel.")
-        return get_orders(manager.get_board(ctx.guild.id), player)
-        # return manager.draw_moves_map(ctx.guild.id, player)
+        file_name = manager.draw_moves_map(ctx.guild.id, player)
+        return get_orders(manager.get_board(ctx.guild.id), player), file_name
 
     raise PermissionError("You cannot view orders because you are neither a GM nor a player.")
 
 
-def adjudicate(ctx: commands.Context, manager: Manager) -> str:
+def adjudicate(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     if not is_gm(ctx.message.author):
         raise PermissionError("You cannot adjudicate because you are not a GM.")
 
@@ -92,23 +92,23 @@ def adjudicate(ctx: commands.Context, manager: Manager) -> str:
         raise PermissionError("You cannot adjudicate in a non-GM channel.")
 
     manager.adjudicate(ctx.guild.id)
-    return "Adjudication completed successfully."
+    return "Adjudication completed successfully.", None  # TODO return file name
 
 
-def rollback(ctx: commands.Context, manager: Manager) -> str:
+def rollback(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     if not is_gm(ctx.message.author):
         raise PermissionError("You cannot rollback because you are not a GM.")
 
     if not is_gm_channel(ctx.channel):
         raise PermissionError("You cannot rollback in a non-GM channel.")
 
-    return manager.rollback()
+    return manager.rollback(), None  # TODO return file name
 
 
 # TODO: (QOL) this doesn't work right now
 # TODO: (QOL) allow players to use this
 # TODO: (QOL) include VSCC calculations
-def get_scoreboard(ctx: commands.Context, manager: Manager) -> str:
+def get_scoreboard(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     if not is_gm(ctx.message.author):
         raise PermissionError("You cannot get the scoreboard because you are not a GM.")
 
@@ -119,10 +119,10 @@ def get_scoreboard(ctx: commands.Context, manager: Manager) -> str:
     for player, count in manager.get_board(ctx.guild.id).get_build_counts():
         response += f"{player} {count}\n"
 
-    return response
+    return response, None
 
 
-def edit(ctx: commands.Context, manager: Manager) -> str:
+def edit(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     # TODO: (BETA) allow Admins in hub server in bot channel to edit constant map features
     if not is_gm(ctx.message.author):
         raise PermissionError("You cannot edit the game state because you are not a GM.")
@@ -130,17 +130,17 @@ def edit(ctx: commands.Context, manager: Manager) -> str:
     if not is_gm_channel(ctx.channel):
         raise PermissionError("You cannot edit the game state in a non-GM channel.")
 
-    return parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id))
+    return parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id)), None
 
 
-def create_game(ctx: commands.Context, manager: Manager) -> str:
+def create_game(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     if not is_gm(ctx.message.author):
         raise PermissionError("You cannot create the game because you are not a GM.")
 
     if not is_gm_channel(ctx.channel):
         raise PermissionError("You cannot create the game in a non-GM channel.")
 
-    return manager.create_game(ctx.guild.id)
+    return manager.create_game(ctx.guild.id), None  # TODO return file name
 
 
 # TODO: (BETA) implement new command for inputting new variant

--- a/diplomacy/adjudicator/mapper.py
+++ b/diplomacy/adjudicator/mapper.py
@@ -118,6 +118,7 @@ class Mapper:
                 self._draw_order(build_order, build_order.location.primary_unit_coordinate)
 
         svg_file_name = f"{self.board.phase.name}_moves_map.svg"
+        self._moves_svg.write(svg_file_name)
         return svg_file_name
 
     def draw_current_map(self) -> None:

--- a/diplomacy/adjudicator/mapper.py
+++ b/diplomacy/adjudicator/mapper.py
@@ -4,7 +4,6 @@ import math
 import re
 import sys
 from xml.etree.ElementTree import ElementTree, Element
-from cairosvg import svg2png
 
 from lxml import etree
 
@@ -119,11 +118,7 @@ class Mapper:
                 self._draw_order(build_order, build_order.location.primary_unit_coordinate)
 
         svg_file_name = f"{self.board.phase.name}_moves_map.svg"
-        png_file_name = f"{self.board.phase.name}_moves_map.png"
-        self._moves_svg.write(svg_file_name)
-        with open(svg_file_name) as svg_file:
-            svg2png(file_obj=svg_file, write_to=png_file_name)
-        return png_file_name
+        return svg_file_name
 
     def draw_current_map(self) -> None:
         self.board_svg.write(f"{self.board.phase.name}_map.svg")

--- a/diplomacy/adjudicator/mapper.py
+++ b/diplomacy/adjudicator/mapper.py
@@ -4,6 +4,7 @@ import math
 import re
 import sys
 from xml.etree.ElementTree import ElementTree, Element
+from cairosvg import svg2png
 
 from lxml import etree
 
@@ -98,7 +99,7 @@ class Mapper:
     # TODO: (!) manually assert all phantom coordinates on provinces and coasts are set, fix if not
     # TODO: (BETA) print svg moves & results files in Discord GM channel
     # TODO: (DB) let's not have a ton of old files: delete moves & results after output (or don't store at all?)
-    def draw_moves_map(self, player_restriction: Player | None) -> None:
+    def draw_moves_map(self, player_restriction: Player | None) -> str:
         self._reset_moves_map()
 
         for unit in self.board.units:
@@ -117,7 +118,12 @@ class Mapper:
             for build_order in player.build_orders:
                 self._draw_order(build_order, build_order.location.primary_unit_coordinate)
 
-        self._moves_svg.write(f"{self.board.phase.name}_moves_map.svg")
+        svg_file_name = f"{self.board.phase.name}_moves_map.svg"
+        png_file_name = f"{self.board.phase.name}_moves_map.png"
+        self._moves_svg.write(svg_file_name)
+        with open(svg_file_name) as svg_file:
+            svg2png(file_obj=svg_file, write_to=png_file_name)
+        return png_file_name
 
     def draw_current_map(self) -> None:
         self.board_svg.write(f"{self.board.phase.name}_map.svg")

--- a/diplomacy/map_parser/vector/config_player.py
+++ b/diplomacy/map_parser/vector/config_player.py
@@ -13,7 +13,7 @@ player_to_color: dict[str, str] = {
     "Inuit": "afc5d8",
     "Kongo": "9f52c4",
     "Mali": "7a9025",
-    "Mapuche-Teheulche": "81889d",
+    "Mapuche-Tehuelche": "81889d",
     "Ming": "cadd7e",
     "Mughal": "ab9f26",
     "Netherlands": "fc9c23",

--- a/diplomacy/persistence/manager.py
+++ b/diplomacy/persistence/manager.py
@@ -38,8 +38,8 @@ class Manager:
             raise RuntimeError("There is no existing game this this server.")
         return board
 
-    def draw_moves_map(self, server_id: int, player_restriction: Player | None) -> None:
-        Mapper(self._boards[server_id]).draw_moves_map(player_restriction)
+    def draw_moves_map(self, server_id: int, player_restriction: Player | None) -> str:
+        return Mapper(self._boards[server_id]).draw_moves_map(player_restriction)
 
     def adjudicate(self, server_id: int) -> None:
         mapper = Mapper(self._boards[server_id])


### PR DESCRIPTION
I also tried to do some SVG -> PNG conversions
From this list:
https://stackoverflow.com/questions/6589358/convert-svg-to-png-in-python

`from cairosvg import svg2png` -- was able to install, got errors when running

Installing inkscape and invoking it on command line -- inkscape is not available for Amazon Linux 2023
Amazon Linux is based on fedora, and inkscape *is* available for fedora through EPEL, but this is what amazon has to say about it -- https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html#epel

`pyrsvg` // `librsvg` -- this is what I was going to try next. It seems to be still updated, so it's promising! Was able to install librsvg on the amazon ec2 machine, but was having trouble finding the corresponding python package (pip couldnt find it)