### PR TITLE
Added 'phase' to DB tables, so when we adjudicate we can roll back

### DIFF
--- a/SQL/1-AddPhaseToKey.sql
+++ b/SQL/1-AddPhaseToKey.sql
@@ -1,0 +1,63 @@
+DROP TABLE IF EXISTS boards_tmp;
+DROP TABLE IF EXISTS players_tmp;
+DROP TABLE IF EXISTS provinces_tmp;
+DROP TABLE IF EXISTS units_tmp;
+
+CREATE TABLE boards_tmp AS SELECT * FROM boards;
+CREATE TABLE players_tmp AS SELECT * FROM players;
+CREATE TABLE provinces_tmp AS SELECT * FROM provinces;
+CREATE TABLE units_tmp AS SELECT * FROM units;
+
+ALTER TABLE provinces_tmp ADD COLUMN phase text;
+ALTER TABLE units_tmp ADD COLUMN phase text;
+
+UPDATE provinces_tmp SET phase='Spring Moves';
+UPDATE units_tmp SET phase='Spring Moves';
+
+DROP TABLE boards;
+DROP TABLE players;
+DROP TABLE provinces;
+DROP TABLE units;
+
+CREATE TABLE boards (
+    board_id int,
+    phase text,
+    map_file text,
+    PRIMARY KEY (board_id, phase));
+CREATE TABLE players (
+    board_id int,
+    player_name text,
+    color varchar(6),
+    PRIMARY KEY (board_id, player_name),
+    FOREIGN KEY (board_id) REFERENCES boards (board_id));
+CREATE TABLE provinces (
+    board_id int,
+    phase text,
+    province_name text,
+    owner text,
+    core text,
+    half_core text,
+    PRIMARY KEY (board_id, phase, province_name),
+    FOREIGN KEY (board_id, phase) REFERENCES boards (board_id, phase),
+    FOREIGN KEY (board_id, owner) REFERENCES players (board_id, player_name),
+    FOREIGN KEY (board_id, core) REFERENCES players (board_id, player_name),
+    FOREIGN KEY (board_id, half_core) REFERENCES players (board_id, player_name));
+CREATE TABLE units (
+    board_id int,
+    phase text,
+    location text,
+    is_dislodged boolean,
+    owner text,
+    is_army boolean,
+    order_type text,
+    order_destination text,
+    order_source text,
+    PRIMARY KEY (board_id, phase, location, is_dislodged),
+    FOREIGN KEY (board_id, phase) REFERENCES boards (board_id, phase),
+    FOREIGN KEY (board_id, phase, location) REFERENCES provinces (board_id, phase, province_name),
+    FOREIGN KEY (board_id, owner) REFERENCES players (board_id, player_name));
+
+INSERT INTO boards SELECT board_id, phase, map_file FROM boards_tmp;
+INSERT INTO players SELECT board_id, player_name, color FROM players_tmp;
+INSERT INTO provinces SELECT board_id, phase, province_name, owner, core, half_core FROM provinces_tmp;
+INSERT INTO units SELECT board_id, phase, location, is_dislodged, owner, is_army, order_type, order_destination, order_source FROM units_tmp;

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -60,7 +60,7 @@ def parse_order(message: str, player_restriction: Player | None, board: Board, b
             invalid.append((command, error))
 
     database = get_connection()
-    database.save_order_for_units(board_id, list(updated_units))
+    database.save_order_for_units(board_id, board.phase.name, list(updated_units))
 
     if invalid:
         response = "The following orders were invalid:"
@@ -87,7 +87,7 @@ def parse_remove_order(message: str, player_restriction: Player | None, board: B
             invalid.append((command, error))
 
     database = get_connection()
-    database.save_order_for_units(board_id, list(updated_units))
+    database.save_order_for_units(board_id, board.phase.name, list(updated_units))
 
     if invalid:
         response = "The following order removals were invalid:"

--- a/diplomacy/persistence/db/database.py
+++ b/diplomacy/persistence/db/database.py
@@ -48,7 +48,14 @@ class _DatabaseConnection:
         logger.info(f"Loading {len(board_data)} boards from DB")
         boards = dict()
         for board_row in board_data:
-            board_id, svg_file, phase_string = board_row
+            board_id, phase_string, svg_file = board_row
+
+            # TODO - THIS WILL BREAK EVERYTHING ONCE WE HIT WINTER!!
+            #  we need to add year into phases. This is a temporary solution.
+            phase = next(phase for phase in phases if phase.name == phase_string)
+            if (board_id, phase.next.name, svg_file) in board_data:
+                continue
+
             logger.info(f"Loading board with ID {board_id}")
 
             # TODO - we should eventually store things like coords, adjacencies, etc
@@ -71,14 +78,15 @@ class _DatabaseConnection:
                 # TODO - player build orders
 
             province_data = cursor.execute(
-                "SELECT province_name, owner, core, half_core FROM provinces WHERE board_id=?", (board_id,)
+                "SELECT province_name, owner, core, half_core FROM provinces WHERE board_id=? and phase=?",
+                (board_id, phase_string),
             ).fetchall()
             province_info_by_name = {
                 province_name: (owner, core, half_core) for province_name, owner, core, half_core in province_data
             }
             unit_data = cursor.execute(
-                "SELECT location, is_dislodged, owner, is_army, order_type, order_destination, order_source FROM units WHERE board_id=?",
-                (board_id,),
+                "SELECT location, is_dislodged, owner, is_army, order_type, order_destination, order_source FROM units WHERE board_id=? and phase=?",
+                (board_id, phase_string),
             ).fetchall()
 
             for province in board.provinces:
@@ -168,17 +176,18 @@ class _DatabaseConnection:
         # TODO: Check if board already exists
         cursor = self._connection.cursor()
         cursor.execute(
-            "INSERT INTO boards (board_id, map_file, phase) VALUES (?, ?, ?);", (board_id, SVG_PATH, board.phase.name)
+            "INSERT INTO boards (board_id, phase, map_file) VALUES (?, ?, ?);", (board_id, board.phase.name, SVG_PATH)
         )
         cursor.executemany(
             "INSERT INTO players (board_id, player_name, color) VALUES (?, ?, ?)",
             [(board_id, player.name, player.color) for player in board.players],
         )
         cursor.executemany(
-            "INSERT INTO provinces (board_id, province_name, owner, core, half_core) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO provinces (board_id, phase, province_name, owner, core, half_core) VALUES (?, ?, ?, ?, ?, ?)",
             [
                 (
                     board_id,
+                    board.phase.name,
                     province.name,
                     province.owner.name if province.owner else None,
                     province.core.name if province.core else None,
@@ -189,10 +198,11 @@ class _DatabaseConnection:
         )
         # TODO - this is hacky
         cursor.executemany(
-            "INSERT INTO units (board_id, location, is_dislodged, owner, is_army, order_type, order_destination, order_source) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO units (board_id, phase, location, is_dislodged, owner, is_army, order_type, order_destination, order_source) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     board_id,
+                    board.phase.name,
                     unit.coast.name if unit.coast is not None else unit.province.name,
                     unit == unit.province.dislodged_unit,
                     unit.player.name,
@@ -207,16 +217,17 @@ class _DatabaseConnection:
         cursor.close()
         self._connection.commit()
 
-    def save_order_for_units(self, board_id: int, units: list[Unit]):
+    def save_order_for_units(self, board_id: int, phase_name: str, units: list[Unit]):
         cursor = self._connection.cursor()
         cursor.executemany(
-            "UPDATE units SET order_type=?, order_destination=?, order_source=? WHERE board_id=? and location=? and is_dislodged=?",
+            "UPDATE units SET order_type=?, order_destination=?, order_source=? WHERE board_id=? and phase=? and location=? and is_dislodged=?",
             [
                 (
                     unit.order.__class__.__name__ if unit.order is not None else None,
                     getattr(getattr(unit.order, "destination", None), "name", None) if unit.order is not None else None,
                     getattr(getattr(unit.order, "source", None), "name", None) if unit.order is not None else None,
                     board_id,
+                    phase_name,
                     unit.province.name,
                     unit.province.dislodged_unit == unit,
                 )

--- a/diplomacy/persistence/db/schema.sql
+++ b/diplomacy/persistence/db/schema.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS boards (
     board_id int,
-    map_file text,
     phase text,
-    PRIMARY KEY (board_id));
+    map_file text,
+    PRIMARY KEY (board_id, phase));
 CREATE TABLE IF NOT EXISTS players (
     board_id int,
     player_name text,
@@ -11,17 +11,19 @@ CREATE TABLE IF NOT EXISTS players (
     FOREIGN KEY (board_id) REFERENCES boards (board_id));
 CREATE TABLE IF NOT EXISTS provinces (
     board_id int,
+    phase text,
     province_name text,
     owner text,
     core text,
     half_core text,
-    PRIMARY KEY (board_id, province_name),
-    FOREIGN KEY (board_id) REFERENCES boards (board_id),
+    PRIMARY KEY (board_id, phase, province_name),
+    FOREIGN KEY (board_id, phase) REFERENCES boards (board_id, phase),
     FOREIGN KEY (board_id, owner) REFERENCES players (board_id, player_name),
     FOREIGN KEY (board_id, core) REFERENCES players (board_id, player_name),
     FOREIGN KEY (board_id, half_core) REFERENCES players (board_id, player_name));
 CREATE TABLE IF NOT EXISTS units (
     board_id int,
+    phase text,
     location text,
     is_dislodged boolean,
     owner text,
@@ -29,7 +31,7 @@ CREATE TABLE IF NOT EXISTS units (
     order_type text,
     order_destination text,
     order_source text,
-    PRIMARY KEY (board_id, location, is_dislodged),
-    FOREIGN KEY (board_id) REFERENCES boards (board_id),
-    FOREIGN KEY (board_id, location) REFERENCES provinces (board_id, province_name),
+    PRIMARY KEY (board_id, phase, location, is_dislodged),
+    FOREIGN KEY (board_id, phase) REFERENCES boards (board_id, phase),
+    FOREIGN KEY (board_id, phase, location) REFERENCES provinces (board_id, phase, province_name),
     FOREIGN KEY (board_id, owner) REFERENCES players (board_id, player_name));


### PR DESCRIPTION
To migrate:

1. back up the .sqlite file (make a copy named bot_db.bkup or something)
2. run the SQL script in SQL/1-AddPhaseToKey.sql
 - on the AWS box, open up sqlite console with `sqlite3 bot_db.sqlite`, then inside the console run `.read SQL/1-AddPhaseToKey.sql`
 - in PyCharm, double click the bot_db.sqlite so it pulls up that database as a 'source' (configure it as sqlite if you havent), then right-click the SQL script and hit the 'Run 1-AddPhaseToKey.sql' option, then set the bot_db as the target
3. make sure it worked

The python side of this is untested. The SQL script side of it works just fine.