### PR TITLE
update sidepanel scoreboard on map

### DIFF
--- a/bot/command.py
+++ b/bot/command.py
@@ -144,9 +144,7 @@ def remove_all(ctx: commands.Context, manager: Manager) -> tuple[str, str | None
 def get_scoreboard(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
     board = manager.get_board(ctx.guild.id)
     response = ""
-    for player in sorted(
-        board.players, key=lambda sort_player: (len(sort_player.centers) / sort_player.vscc), reverse=True
-    ):
+    for player in board.get_players_sorted_by_vscc():
         response += f"\n__{player.name}__: {len(player.centers)} ({'+' if len(player.centers) - len(player.units) >= 0 else ''}{len(player.centers) - len(player.units)})"
     return response, None
 

--- a/diplomacy/map_parser/vector/config_svg.py
+++ b/diplomacy/map_parser/vector/config_svg.py
@@ -23,7 +23,9 @@ SUPPLY_CENTER_LAYER_ID: str = "layer3"
 # Layer group in SVG containing units
 UNITS_LAYER_ID: str = "layer10"
 # Layer group in SVG containing the date
-SEASON_TITLE_LAYER_ID = "layer4"
+SEASON_TITLE_LAYER_ID: str = "layer4"
+# Layer group in SVG contianing the power banners
+POWER_BANNERS_LAYER_ID: str = "layer13"
 
 # Layer groups in SVG containing phantom units for optimal unit placements
 PHANTOM_PRIMARY_ARMY_LAYER_ID: str = "g652"

--- a/diplomacy/map_parser/vector/utils.py
+++ b/diplomacy/map_parser/vector/utils.py
@@ -8,15 +8,15 @@ from diplomacy.persistence.unit import UnitType
 def get_svg_element(svg_root: ElementTree, element_id: str) -> Element:
     return svg_root.xpath(f'//*[@id="{element_id}"]')[0]
 
-
-def get_player(element: Element, color_to_player: dict[str, Player]) -> Player:
+def get_element_color(element: Element) -> str:
     style = element.get("style").split(";")
     for value in style:
         prefix = "fill:#"
         if value.startswith(prefix):
-            color = value[len(prefix) :]
-            return color_to_player[color]
+            return value[len(prefix) :]
 
+def get_player(element: Element, color_to_player: dict[str, Player]) -> Player:
+    return color_to_player[get_element_color(element)]
 
 def _get_unit_type(unit_data: Element) -> UnitType:
     num_sides = unit_data.get("{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}sides")

--- a/diplomacy/map_parser/vector/vector.py
+++ b/diplomacy/map_parser/vector/vector.py
@@ -44,6 +44,7 @@ class Parser:
         self.names_layer: Element = get_svg_element(svg_root, PROVINCE_NAMES_LAYER_ID)
         self.centers_layer: Element = get_svg_element(svg_root, SUPPLY_CENTER_LAYER_ID)
         self.units_layer: Element = get_svg_element(svg_root, UNITS_LAYER_ID)
+        self.power_banner_layer: Element = get_svg_element(svg_root, POWER_BANNERS_LAYER_ID)
 
         self.phantom_primary_armies_layer: Element = get_svg_element(svg_root, PHANTOM_PRIMARY_ARMY_LAYER_ID)
         self.phantom_retreat_armies_layer: Element = get_svg_element(svg_root, PHANTOM_RETREAT_ARMY_LAYER_ID)

--- a/diplomacy/persistence/board.py
+++ b/diplomacy/persistence/board.py
@@ -25,6 +25,11 @@ class Board:
         # we ignore capitalization because this is primarily used for user input
         return next((player for player in self.players if player.name.lower() == name.lower()), None)
 
+    def get_players_sorted_by_vscc(self) -> list[Player]:
+        return sorted(
+            self.players, key=lambda sort_player: (len(sort_player.centers) / sort_player.vscc), reverse=True
+        )
+
     # TODO: we could have this as a dict ready on the variant
     def get_province(self, name: str) -> Province:
         # we ignore capitalization because this is primarily used for user input


### PR DESCRIPTION
- use the existing `draw_side_panel` in the mapper to include processing of the scoreboard
- main logic is to just swap around the transform translation values of the existing svg elements in the layer