### PR TITLE
Add bot to cgroup

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,4 +8,23 @@ if not log_level:
     log_level = logging.INFO
 logging.basicConfig(level=log_level)
 
+logger = logging.getLogger(__name__)
+
+try:
+    # Create a cgroup for the bot, if one doesn't already exist
+    CGROUP_DIR = "/sys/fs/cgroup/diplomacy_gm"
+    os.makedirs(CGROUP_DIR, exist_ok=True)
+
+    # Set the cgroup's memory limit to 1GB (arbitrary choice)
+    with open(f"{CGROUP_DIR}/memory.max", "w") as f:
+        f.write("1G")
+
+    # Add this process to the cgroup so it's limited by the memory limit
+    with open(f"{CGROUP_DIR}/cgroup.procs", "w") as f:
+        f.write(str(os.getpid()))
+except Exception as e:
+    # No big deal if we can't create a cgroup for the bot; swallow the exception
+    # Also, cgroups don't exist on macos/windows, so this will fail there deterministically
+    logger.warning(f"Failed to add the bot to a cgroup with limited memory use, got exception {e}")
+
 bot.run()


### PR DESCRIPTION
This change limits the amount of memory the bot process can use (on Linux only).

The bot has been going down frequently recently, and icecreamguy suggests that memory pressure may be to blame, given that during the outages it's not possible to ssh to the bot VM.

Limiting the memory use won't do anything to address the crashes themselves, but it should allow SSHing into the node to debug what's going wrong.

I can launch the bot locally with these changes, but I don't have a Linux machine handy to confirm that this works. In the worst case, if this is totally broken, the bot logs an extra exception and moves on with its life as before.

Also, I have no idea which OS/version the VM the bot runs on is using. If it's not Linux, this is useless and we should close it. I wrote this for cgroups v2, but if the vm is too old to support that we'll have to do something slightly different for cgroups v1.