### PR TITLE
Fix high sea adjacencies and minor coring behavior

### DIFF
--- a/diplomacy/adjudicator/adjudicator.py
+++ b/diplomacy/adjudicator/adjudicator.py
@@ -553,10 +553,11 @@ class MovesAdjudicator(Adjudicator):
             # Resolution is arbitrary for holds; they don't do anything
             return Resolution.SUCCEEDS
         elif order.type == OrderType.CORE or order.type == OrderType.SUPPORT:
-            # Both these orders fail if attacked by another nation, even if that order isn't successful
+            # Both these orders fail if attacked by nation, even if that order isn't successful
             moves_here = self.moves_by_destination.get(order.current_province.name, set()) - {order}
             for move_here in moves_here:
-                if move_here.country == order.country:
+                # coring should fail even if the attack comes from the same nation
+                if move_here.country == order.country and order.type == OrderType.SUPPORT:
                     continue
                 if not move_here.is_convoy:
                     if move_here.current_province != order.destination_province:

--- a/diplomacy/map_parser/vector/vector.py
+++ b/diplomacy/map_parser/vector/vector.py
@@ -166,6 +166,7 @@ class Parser:
             return
         if "high provinces" in self.data["overrides"]:
             for name, data in self.data["overrides"]["high provinces"].items():
+                high_provinces: list[Province] = []
                 for index in range(1, data["num"] + 1):
                     province = Province(
                         name + str(index),
@@ -181,6 +182,14 @@ class Parser:
                         None,
                     )
                     provinces = self.add_province_to_board(provinces, province)
+                    high_provinces.append(province)
+
+                # Add connections between each high province
+                for provinceA in high_provinces:
+                    for provinceB in high_provinces:
+                        if provinceA.name != provinceB.name:
+                            provinceA.adjacent.add(provinceB)
+
             for name, data in self.data["overrides"]["high provinces"].items():
                 adjacent = tuple(self.names_to_provinces(data["adjacencies"]))
                 for index in range(1, data["num"] + 1):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,19 +1,9 @@
 import unittest
 
-from diplomacy.persistence.order import (
-    Support,
-)
 from diplomacy.persistence.unit import UnitType
 from test.utils import BoardBuilder
 
 class TestCore(unittest.TestCase):
-    # test - coring turns empty into half_core, 
-    # half_core into core
-    # fails when attacked by enemy unit
-    # fails when attacked by unit
-    # fails when attacked by convoy
-    # doesn't fail when attacked by disrupted convoy
-
     def test_core_1(self):
         """ 
             Coring should fail for non-SCs.

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,179 @@
+import unittest
+
+from diplomacy.persistence.order import (
+    Support,
+)
+from diplomacy.persistence.unit import UnitType
+from test.utils import BoardBuilder
+
+class TestCore(unittest.TestCase):
+    # test - coring turns empty into half_core, 
+    # half_core into core
+    # fails when attacked by enemy unit
+    # fails when attacked by unit
+    # fails when attacked by convoy
+    # doesn't fail when attacked by disrupted convoy
+
+    def test_core_1(self):
+        """ 
+            Coring should fail for non-SCs.
+            Germany: A Rumania Cores
+            Rumania shouldn't be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        a_rumania = b.core(b.germany, UnitType.ARMY, b.rumania)
+
+        b.assertIllegal(a_rumania)
+        b.moves_adjudicate(self)
+        self.assertFalse(b.rumania.half_core == b.germany, "Rumania shouldn't be cored")
+
+    def test_core_2(self):
+        """ 
+            Coring should fail for not owned provinces.
+            Germany doesn't own Holland.
+            Germany: A Holland Cores
+            Holland shouldn't be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+
+        b.assertIllegal(a_holland)
+        b.moves_adjudicate(self)
+        self.assertFalse(b.holland.half_core == b.germany, "Holland shouldn't be cored")
+
+    def test_core_3(self):
+        """ 
+            Coring should turn empty cores into half cores.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            Holland should be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+
+        b.assertSuccess(a_holland)
+        b.moves_adjudicate(self)
+        print(b.holland.half_core)
+        self.assertTrue(b.holland.half_core == b.germany, "Holland should be half-cored")
+
+    def test_core_4(self):
+        """ 
+            Coring should turn half cores into full cores.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            Holland should be cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+
+        b.assertSuccess(a_holland)
+        b.moves_adjudicate(self)
+        print(b.holland.half_core)
+        self.assertTrue(b.holland.core == b.germany, "Holland should be cored")
+
+    def test_core_5(self):
+        """ 
+            Coring should failed when the coring unit is attacked.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            France: A Belgium - Holland
+            Holland shouldn't be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+        a_belgium = b.move(b.france, UnitType.ARMY, b.belgium, b.holland)
+
+        b.assertFail(a_holland, a_belgium)
+        b.assertNotIllegal(a_holland, a_belgium)
+        b.moves_adjudicate(self)
+        
+        self.assertFalse(b.holland.core == b.germany, "Holland shouldn't be cored")
+
+    def test_core_5(self):
+        """ 
+            Coring should failed when the attacking unit is of the same nationality.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            Germany: A Belgium - Holland
+            Holland shouldn't be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+        a_belgium = b.move(b.germany, UnitType.ARMY, b.belgium, b.holland)
+
+        b.assertFail(a_holland, a_belgium)
+        b.assertNotIllegal(a_holland, a_belgium)
+        b.moves_adjudicate(self)
+        
+        self.assertFalse(b.holland.core == b.germany, "Holland shouldn't be half-cored")
+
+    def test_core_6(self):
+        """ 
+            Coring should fail when attacked by convoy.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            England: A London - Holland
+            England: F North Sea Convoys A London - Holland
+            Holland should be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+        a_london = b.move(b.england, UnitType.ARMY, b.london, b.holland)
+        f_north_sea = b.convoy(b.england, b.north_sea, a_london, b.holland)
+
+        b.assertFail(a_holland, a_london)
+        b.assertNotIllegal(a_holland, f_north_sea, a_london)
+        b.moves_adjudicate(self)
+        
+        self.assertFalse(b.holland.core == b.germany, "Holland shouldn't be half-cored")
+
+    def test_core_7(self):
+        """ 
+            Coring should failed when attacked by convoy of the same nationality.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            Germany: A London - Holland
+            England: F North Sea Convoys A London - Holland
+            Holland should be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+        a_london = b.move(b.germany, UnitType.ARMY, b.london, b.holland)
+        f_north_sea = b.convoy(b.england, b.north_sea, a_london, b.holland)
+
+        b.assertFail(a_holland, a_london)
+        b.assertNotIllegal(a_holland, f_north_sea, a_london)
+        b.moves_adjudicate(self)
+        
+        self.assertFalse(b.holland.core == b.germany, "Holland shouldn't be half-cored")
+
+
+    def test_core_8(self):
+        """ 
+            Coring should succeed when only attacked by a disrupted convoy.
+            Germany owns Holland.
+            Germany: A Holland Cores
+            England: A London - Holland
+            Holland should be half-cored by Germany.
+        """
+        b = BoardBuilder()
+        b.holland.owner = b.germany
+        b.holland.half_core = b.germany
+        a_holland = b.core(b.germany, UnitType.ARMY, b.holland)
+        a_london = b.move(b.england, UnitType.ARMY, b.london, b.holland)
+
+        b.assertSuccess(a_holland)
+        b.moves_adjudicate(self)
+        
+        self.assertTrue(b.holland.core == b.germany, "Holland should be half-cored")

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,6 @@
 from diplomacy.persistence.board import Board
 from diplomacy.persistence.order import (
+    Core,
     Hold,
     Move,
     RetreatMove,
@@ -150,7 +151,7 @@ class BoardBuilder():
         self.rumania = self._land("Rumania")
         self.rumania_c = self._coast("m", self.rumania)
         self.budapest = self._land("Budapest")
-        self.holland = self._land("Holland")
+        self.holland = self._land("Holland", sc=True)
         self.holland_c = self._coast("m", self.holland)
         self.edinburgh = self._land("Edinburgh")
         self.edinburgh_c = self._coast("m", self.edinburgh)
@@ -405,6 +406,17 @@ class BoardBuilder():
             unit = self.army(place, player)
 
         order = Move(to)
+        unit.order = order
+
+        return unit
+
+    def core(self, player: Player, type: UnitType, place: Location) -> Unit:
+        if (type == UnitType.FLEET):
+            unit = self.fleet(place, player)
+        else:
+            unit = self.army(place, player)
+
+        order = Core()
         unit.order = order
 
         return unit


### PR DESCRIPTION
- High provinces aren't actually considered to be adjacent to other high provinces right now, this fixes that by just registering them as adjacent.
- According to the player guide, attacking your own coring unit should fail the coring action. This implements this, which would stop the hypothetical ability to support attack your own coring unit to prevent dislodges. This also adds a series of tests to test coring behavior.