### PR TITLE
Remove convoy orders and support more aliases

### DIFF
--- a/diplomacy/adjudicator/adjudicator.py
+++ b/diplomacy/adjudicator/adjudicator.py
@@ -299,8 +299,8 @@ class RetreatsAdjudicator(Adjudicator):
             if unit != unit.province.dislodged_unit:
                 continue
 
-            if isinstance(unit.order, RetreatMove) and unit.order.destination in unit.retreat_options:
-                destination_province = get_base_province_from_location(unit.order.destination)
+            destination_province = get_base_province_from_location(unit.order.destination)
+            if isinstance(unit.order, RetreatMove) and destination_province in unit.retreat_options:
                 if destination_province.name not in retreats_by_destination:
                     retreats_by_destination[destination_province.name] = set()
                 retreats_by_destination[destination_province.name].add(unit)

--- a/diplomacy/map_parser/common/parser.py
+++ b/diplomacy/map_parser/common/parser.py
@@ -1,0 +1,15 @@
+import copy
+import logging
+from diplomacy.map_parser.common.result import ParserResult
+from diplomacy.map_parser.vector.vector import Parser
+from diplomacy.persistence.board import Board
+
+logger = logging.getLogger(__name__)
+    
+parsers: dict[str, ParserResult] = {}
+
+def parse_board(name: str) -> Board:
+    if name not in parsers:
+        logger.info(f"Creating new Parser for board named {name}")
+        parsers[name] = Parser(name)
+    return parsers[name].parse().make_board()

--- a/diplomacy/map_parser/common/result.py
+++ b/diplomacy/map_parser/common/result.py
@@ -1,0 +1,96 @@
+import copy
+import logging
+from diplomacy.persistence.board import Board
+from diplomacy.persistence.phase import Phase, initial
+from diplomacy.persistence.player import Player
+from diplomacy.persistence.province import Coast, Province
+from diplomacy.persistence.unit import Unit
+
+logger = logging.getLogger(__name__)
+
+def copyset[T](m: dict[T,T], s: set[T]) -> set[T]:
+    return {m[x] for x in s}
+
+class ParserResult:
+    def __init__(self, players, provinces, units, phase, data, datafile: str):
+        # partially instantiated players, provinces, units
+        self.players: set[Player] = players
+        self.provinces: set[Province] = provinces
+        self.units: set[Unit] = units
+
+        # (name, set of (coast name, coast adjacencies))
+        self.coast_overrides: set[tuple[str, set[tuple[str, set[str]]]]] = set()
+
+        self.adjacencies: set[tuple[Province, Province]] = set()
+
+        self.phase = phase
+        self.data = data
+        self.datafile = datafile
+
+        self.province_to_owner: dict[Province, Player] = {}
+
+    def add_province(self, province: Province) -> set[Province]:
+        if self.name_to_province.get(province.name) != None:
+            raise ValueError(f"Duplicate province {province.name}")
+
+        self.provinces.add(province)
+        self.name_to_province[province.name] = province
+
+    # deepcopy and re-link all references manually
+    def make_board(self) -> Board:
+        player_map: dict[Player, Player] = {}
+        province_map: dict[Province, Province] = {}
+        unit_map: dict[Unit, Unit] = {}
+        coast_map: dict[Coast, Coast] = {}
+
+        for player in self.players:
+            player_map[player] = copy.copy(player)
+
+        for province in self.provinces:
+            province_map[province] = copy.copy(province)
+
+        for unit in self.units:
+            unit_map[unit] = copy.copy(unit)
+
+        for old, new in player_map.items():
+            new.centers = copyset(province_map, old.centers)
+            new.units = copyset(unit_map, old.units)
+
+        for old, new in province_map.items():
+            new.adjacent = copyset(province_map, old.adjacent)
+            new_coasts = set()
+            for coast in old.coasts:
+                new_coast = Coast(coast.name, coast.primary_unit_coordinate, coast.retreat_unit_coordinate,
+                                     copyset(province_map, coast.adjacent_seas), province_map[coast.province])
+                coast_map[coast] = new_coast
+                new_coasts.add(new_coast)
+
+            new.coast = new_coasts
+
+            if old.core != None:
+                new.core = player_map[old.core]
+            if old.owner != None:
+                new.owner = player_map[old.owner]
+            if old.unit != None:
+                new.unit = unit_map[old.unit]
+
+            assert old.corer == None
+            assert old.dislodged_unit == None
+
+        for old, new in unit_map.items():
+            new.player = player_map[old.player]
+            new.province = province_map[old.province]
+            if old.coast != None:
+                new.coast = coast_map[old.coast]
+
+            assert old.retreat_options == None
+            assert old.order == None
+
+        new_provinces = set()
+        for province in province_map.values():
+            new_provinces.add(province)
+
+        for province in self.provinces:
+            province.adjacent = None
+
+        return Board(set(player_map.values()), set(province_map.values()), set(unit_map.values()), self.phase, self.data, self.datafile)


### PR DESCRIPTION
- Removes convoy move orders, which I've been told are leftover from the previous adjudication library; currently, their presence suggests a difference in behavior from normal move orders, which isn't real as convoy kidnapping exists.
- Remove some unused code
- Support all the abbreviations for army / fleet in unit_dict, and support upper case and lower case in applicable regexes
`DESCRIPTOR.2 : /a|army|cannon|f|fleet|boat|ship/i WS`