### PR TITLE
Remove convoy orders and support more aliases

### DIFF
--- a/bot/command.py
+++ b/bot/command.py
@@ -190,7 +190,7 @@ async def botsay(ctx: commands.Context, _: Manager) -> None:
         return
     channel = ctx.message.channel_mentions[0]
     content = ctx.message.content
-    content = content.replace(".botsay", "").replace(channel.mention, "").strip()
+    content = content.removeprefix(".botsay").replace(channel.mention, "").strip()
     if len(content) == 0:
         return
     await ctx.message.add_reaction("👍")

--- a/bot/orders.ebnf
+++ b/bot/orders.ebnf
@@ -10,7 +10,6 @@ build_phase: ".order" (WS build?)? (NL (build? WS? NL) *)?
 order: move_order
     | hold_order
     | support_order
-    | convoy_move_order
     | convoy_order
     | core_order
 
@@ -25,8 +24,6 @@ move_order: unit WS MOVE WS province
 hold_order: unit WS HOLD
 
 support_order: unit WS ((SUPPORT WS (move_order | hold_order)) | ((SUPPORT_HOLD | SUPPORT) WS unit))
-
-convoy_move_order: unit WS CONVOY_MOVE WS province
 
 convoy_order: unit WS CONVOY WS move_order
 
@@ -60,19 +57,6 @@ MOVE.2 : "-"
        | "moves"
        | "moves to"
        | "into"
-
-CONVOY_MOVE.2 : "c-"
-        | "c–"
-        | "cm"
-        | "convoy -"
-        | "convoy –"
-        | "convoy ->"
-        | "convoy –>"
-        | "convoy to"
-        | "convoy m"
-        | "convoy move"
-        | "convoy moves"
-        | "convoy into"
 
 SUPPORT.2 : "s"
         | "support"
@@ -108,7 +92,7 @@ unit : (DESCRIPTOR)? province
 
 retreat_unit : (DESCRIPTOR)? province
 
-DESCRIPTOR.2 : /[afAF]/ WS
+DESCRIPTOR.2 : /a|army|cannon|f|fleet|boat|ship/i WS
 
 province : PROVINCE (WS PROVINCE) *
 

--- a/bot/orders.ebnf
+++ b/bot/orders.ebnf
@@ -37,7 +37,7 @@ disband_unit: ( unit WS DISBAND ) | ( DISBAND WS unit )
 
 build_unit: ( BUILD WS DESCRIPTOR province ) | ( BUILD WS province DESCRIPTOR )
 
-SUPPORT_HOLD.3 : /(support|supports|s)[ \-_]?(hold|holds|h|stand|stands)/
+SUPPORT_HOLD.3 : /(support|supports|s)[ \-_]?(hold|holds|h|stand|stands)/i
 
 HOLD.2 : "h"
        | "hold"


### PR DESCRIPTION
Accidentally broke the previous pull request, apologies for that.

- Removes convoy move orders, which I've been told are leftover from the previous adjudication library; currently, their presence suggests a difference in behavior from normal move orders, which isn't real as convoy kidnapping exists.
- Remove some unused code
- Support all the abbreviations for army / fleet in unit_dict, and support upper case and lower case in applicable regexes
`DESCRIPTOR.2 : /a|army|cannon|f|fleet|boat|ship/i WS`