### PR TITLE
Fix svg path bug

### DIFF
--- a/diplomacy/map_parser/vector/utils.py
+++ b/diplomacy/map_parser/vector/utils.py
@@ -106,7 +106,7 @@ def parse_path(path_string: str, layer_translation: Transform, this_translation:
             if command.lower() == "z":
                 if start == None:
                     raise Exception("Invalid geometry: got 'z' on first element in a subgeometry")
-                province_coordinates[-1].append(start)
+                province_coordinates[-1].append(layer_translation.transform(this_translation.transform(start)))
                 start = None
                 current_index += 1
                 if current_index < len(path):


### PR DESCRIPTION
Found this bug while porting, but in essence the starting position of the loop is not properly transformed while parsing svgs right now, which leads to a decent number of excess adjacencies that shouldn't be there (like natuna sea and banjarmassin). A full list can be found here https://gist.github.com/Incompleteusern/4b8ad175d75e2fbb2a404770bbd9033b.