### PR TITLE
Suggest province if typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lark
 lxml
 discord
 black
+levenshtein


### PR DESCRIPTION
Uses the jaro-winkler algorithm as implemented by `Levenshtein` to find the closest province when there is a typo, replaces the old implementation based off prefixes.

![image](https://github.com/user-attachments/assets/1381dd7c-050d-4014-931d-e1fe92d0dac9)
