### PR TITLE
Enable view_map command for players

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -58,7 +58,7 @@ async def on_ready():
             print(f"Channel with ID {bot_status_channel} not found.")
     else:
         print(f"Guild with ID {impdip_server} not found.")
-    
+
     # Set bot's presence (optional)
     await bot.change_presence(activity=discord.Game(name="Impdip 🔪"))
 
@@ -209,15 +209,18 @@ async def remove_order(ctx: commands.Context) -> None:
 
 @bot.command(
     brief="Outputs your current submitted orders.",
-    description="Outputs your current submitted orders. "
-    "In the future we will support outputting a sample moves map of your orders.",
+    description="Outputs your current submitted orders. ",
     aliases=["view", "vieworders"],
 )
 async def view_orders(ctx: commands.Context) -> None:
     await _handle_command(command.view_orders, ctx)
 
 
-@bot.command(brief="Outputs the current map with submitted orders.")
+@bot.command(
+    brief="Outputs the current map with submitted orders.",
+    description="For admins, all submitted orders are displayed. For a player, only their own orders are displayed.",
+    aliases=["viewmap", "vm"],
+)
 async def view_map(ctx: commands.Context) -> None:
     await _handle_command(command.view_map, ctx)
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -248,11 +248,10 @@ async def view_orders(player: Player | None, ctx: commands.Context, manager: Man
     return order_text
 
 
-@perms.gm("view map")
-async def view_map(ctx: commands.Context, manager: Manager) -> str | dict[str]:
-    # file_name = manager.draw_moves_map(ctx.guild.id, player)
+@perms.player("view map")
+async def view_map(player: Player | None, ctx: commands.Context, manager: Manager) -> str | dict[str]:
     try:
-        file, file_name = manager.draw_moves_map(ctx.guild.id, None)
+        file, file_name = manager.draw_moves_map(ctx.guild.id, player)
     except Exception as err:
         logger.error(f"View_orders map failed in game with id: {ctx.guild.id}", exc_info=err)
         return "View_orders map failed"


### PR DESCRIPTION
The view_map command now also works in player order channels, allowing a player to see their own submitted moves (not those of other players) visualized on the map. GMs can still see _all_ submitted orders of all players in GM channels.