### PR TITLE
Support svg to png

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -126,13 +126,13 @@ async def _handle_command(
         # for some reason zipfile doesn't support this natively
         with io.BytesIO() as vfile:
             zip_file = zipfile.ZipFile(vfile, mode="x", compression=zipfile.ZIP_DEFLATED, compresslevel=9)
-            zip_file.writestr(f"{file_name}.svg", file, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+            zip_file.writestr(f"{file_name}", file, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
             zip_file.close()
             vfile.seek(0)
             await ctx.channel.send(message, file=discord.File(fp=vfile, filename=f"{file_name}.zip"))
     elif file is not None:
         with io.BytesIO(file) as vfile:
-            await ctx.channel.send(message, file=discord.File(fp=vfile, filename=f"{file_name}.svg"))
+            await ctx.channel.send(message, file=discord.File(fp=vfile, filename=f"{file_name}"))
     else:
         await ctx.channel.send(message)
 
@@ -209,15 +209,22 @@ async def remove_order(ctx: commands.Context) -> None:
 
 @bot.command(
     brief="Outputs your current submitted orders.",
-    description="Outputs your current submitted orders. "
-    "In the future we will support outputting a sample moves map of your orders.",
+    description="Outputs your current submitted orders.",
     aliases=["view", "vieworders"],
 )
 async def view_orders(ctx: commands.Context) -> None:
     await _handle_command(command.view_orders, ctx)
 
 
-@bot.command(brief="Outputs the current map with submitted orders.")
+@bot.command(
+    brief="Outputs the current map with submitted orders.",
+    description="""
+    For GMs, all submitted orders are displayed. For a player, only their own orders are displayed.
+    GMs may append true as an argument to this to instead get the svg.
+    * view_map {True|(False) - whether or not to claim SCs}
+    """,
+    aliases=["viewmap", "vm"],
+)
 async def view_map(ctx: commands.Context) -> None:
     await _handle_command(command.view_map, ctx)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -229,7 +229,12 @@ async def view_map(ctx: commands.Context) -> None:
     await _handle_command(command.view_map, ctx)
 
 
-@bot.command(brief="Adjudicates the game and outputs the moves and results maps.")
+@bot.command(brief="Adjudicates the game and outputs the moves and results maps.",
+    description="""
+    GMs may append true as an argument to this command to instead get the base svg file.
+    * adjudicate {True|(False) - whether or not to display as an .svg}
+    """
+)
 async def adjudicate(ctx: commands.Context) -> None:
     await _handle_command(command.adjudicate, ctx)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -221,7 +221,7 @@ async def view_orders(ctx: commands.Context) -> None:
     description="""
     For GMs, all submitted orders are displayed. For a player, only their own orders are displayed.
     GMs may append true as an argument to this to instead get the svg.
-    * view_map {True|(False) - whether or not to claim SCs}
+    * view_map {True|(False) - whether or not to display as an .svg}
     """,
     aliases=["viewmap", "vm"],
 )

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -1,5 +1,6 @@
 from bot.utils import get_unit_type, get_keywords
 from diplomacy.adjudicator.mapper import Mapper
+from diplomacy.adjudicator.utils import svg_to_png
 from diplomacy.persistence import phase
 from diplomacy.persistence.board import Board
 from diplomacy.persistence.db.database import get_connection
@@ -36,7 +37,7 @@ def parse_edit_state(message: str, board: Board) -> dict[str]:
     else:
         response = "Commands validated successfully. Results map updated."
 
-    file, file_name = Mapper(board).draw_current_map()
+    file, file_name = svg_to_png(Mapper(board).draw_current_map())
 
     return {"message": response, "file": file, "file_name": file_name}
 

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -1,6 +1,5 @@
 from bot.utils import get_unit_type, get_keywords
 from diplomacy.adjudicator.mapper import Mapper
-from diplomacy.adjudicator.utils import svg_to_png
 from diplomacy.persistence import phase
 from diplomacy.persistence.board import Board
 from diplomacy.persistence.db.database import get_connection
@@ -37,7 +36,7 @@ def parse_edit_state(message: str, board: Board) -> dict[str]:
     else:
         response = "Commands validated successfully. Results map updated."
 
-    file, file_name = svg_to_png(Mapper(board).draw_current_map())
+    file, file_name = Mapper(board).draw_current_map()
 
     return {"message": response, "file": file, "file_name": file_name}
 

--- a/diplomacy/adjudicator/mapper.py
+++ b/diplomacy/adjudicator/mapper.py
@@ -134,12 +134,12 @@ class Mapper:
 
         self.draw_side_panel(self._moves_svg)
 
-        svg_file_name = f"{self.board.phase.name}_{self.board.year + 1642}_moves_map"
+        svg_file_name = f"{self.board.phase.name}_{self.board.year + 1642}_moves_map.svg"
         return elementToString(self._moves_svg.getroot(), encoding="utf-8"), svg_file_name
 
     def draw_current_map(self) -> tuple[str, str]:
         logger.info("mapper.draw_current_map")
-        svg_file_name = f"{self.board.phase.name}_{self.board.year + 1642}_map"
+        svg_file_name = f"{self.board.phase.name}_{self.board.year + 1642}_map.svg"
         return elementToString(self.state_svg.getroot(), encoding="utf-8"), svg_file_name
 
     def get_pretty_date(self) -> str:

--- a/diplomacy/adjudicator/utils.py
+++ b/diplomacy/adjudicator/utils.py
@@ -1,0 +1,21 @@
+from resvg import render, usvg
+import affine
+import os
+
+def svg_to_png(svg: bytes, file_name: str):
+    db = usvg.FontDatabase.default()
+    db.load_system_fonts()
+
+    options = usvg.Options.default()
+
+    tree = usvg.Tree.from_str(svg.decode(), options, db)
+    scale = 2
+    (w, h) = tree.int_size()
+    target_size = (w*scale, h*scale)
+
+    tr = affine.Affine.scale(scale)
+    data = render(tree, tr[0:6], bg_size=target_size)
+
+    base = os.path.splitext(file_name)[0]
+
+    return bytes(data), base + ".png"

--- a/diplomacy/adjudicator/utils.py
+++ b/diplomacy/adjudicator/utils.py
@@ -5,7 +5,6 @@ import os
 def svg_to_png(svg: bytes, file_name: str):
     db = usvg.FontDatabase.default()
     db.load_system_fonts()
-
     options = usvg.Options.default()
 
     tree = usvg.Tree.from_str(svg.decode(), options, db)
@@ -17,5 +16,4 @@ def svg_to_png(svg: bytes, file_name: str):
     data = render(tree, tr[0:6], bg_size=target_size)
 
     base = os.path.splitext(file_name)[0]
-
     return bytes(data), base + ".png"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ lark>=1.2.2
 lxml>=5.3.1
 discord>=2.3.2
 black>=25.1.0
+affine>=2.4.0
+resvg>=0.1.2


### PR DESCRIPTION
This uses `resvg` bindings to display an svg as a png which the bot can then upload. This is used to embed #112 and allows for players to view their moves on a map. However, this operation is somewhat costly.

This allows for gms to choose whether .adjudicate and .view_map return an svg or png, and currently .edit simply returns an svg.