### PR TITLE
Simultaneous SVG exports

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,6 @@ DISCORD_TOKEN = ""
 
 #Can be INFO, TRACE, DEBUG, etc
 log_level = "DEBUG"
+
+# limits the number of simultaneous Inkscape invocations
+simultaneous_svg_exports_limit = 4

--- a/bot/command.py
+++ b/bot/command.py
@@ -256,7 +256,7 @@ async def view_map(player: Player | None, ctx: commands.Context, manager: Manage
     try:
         file, file_name = manager.draw_moves_map(ctx.guild.id, player)
         if not return_svg or player:
-            file, file_name = svg_to_png(file, file_name)
+            file, file_name = await svg_to_png(file, file_name)
     except Exception as err:
         logger.error(f"View_orders map failed in game with id: {ctx.guild.id}", exc_info=err)
         return "View_orders map failed"
@@ -268,7 +268,7 @@ async def adjudicate(ctx: commands.Context, manager: Manager) -> dict[str]:
     return_svg = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() == "true"
     file, file_name = manager.adjudicate(ctx.guild.id)
     if not return_svg:
-        file, file_name = svg_to_png(file, file_name)
+        file, file_name = await svg_to_png(file, file_name)
     return {"message": "Adjudication completed successfully", "file": file, "file_name": file_name}
 
 


### PR DESCRIPTION
prod .env will need the following added:
```toml
# limits the number of simultaneous Inkscape invocations
simultaneous_svg_exports_limit = 4
```


Bot no longer waits for response from Inkscape and can invoke it multiple times
```python
svg_export_limit = asyncio.Semaphore(int(os.getenv("simultaneous_svg_exports_limit")))

async def svg_to_png(svg: bytes, file_name: str):
    async with svg_export_limit:
        p = await asyncio.create_subprocess_shell("inkscape --pipe --export-type=png --export-dpi=200", stdout=PIPE, stdin=PIPE, stderr=PIPE)
        data = await p.communicate(input=svg)
    data = data[0]
```