### PR TITLE
Uses embeds instead of content in messages

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,3 +7,6 @@ log_level = "DEBUG"
 
 # limits the number of simultaneous Inkscape invocations
 simultaneous_svg_exports_limit = 4
+
+# Command Prefix
+command_prefix = "."

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -6,6 +6,7 @@ from typing import Callable, Awaitable
 import random
 from dotenv.main import load_dotenv
 
+from bot.config import ERROR_COLOUR
 from bot.utils import convert_svg_and_send_file, send_message_and_file
 load_dotenv()
 
@@ -90,7 +91,10 @@ async def on_command_error(ctx, error):
         await ctx.message.add_reaction("❌")
         await ctx.message.remove_reaction("👍", bot.user)
 
-        await send_message_and_file(channel=ctx.channel, message=str(error))
+        if type(error.original) == PermissionError:
+            await send_message_and_file(channel=ctx.channel, message=str(error.original), embed_colour=ERROR_COLOUR)
+        else:
+            await send_message_and_file(channel=ctx.channel, message=str(error), embed_colour=ERROR_COLOUR)
 
 
 async def _handle_command(

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -90,7 +90,7 @@ async def on_command_error(ctx, error):
         await ctx.message.add_reaction("❌")
         await ctx.message.remove_reaction("👍", bot.user)
 
-        await send_message_and_file(ctx.channel, message=str(error))
+        await send_message_and_file(channel=ctx.channel, message=str(error))
 
 
 async def _handle_command(
@@ -118,7 +118,7 @@ async def _handle_command(
 
     elapsed = time.time() - start
     logger.debug(
-        f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}' -> \n{response["message"] or response} | {elapsed}s"
+        f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}' -> \n{response} | {elapsed}s"
     )
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,7 +19,7 @@ from diplomacy.persistence.manager import Manager
 intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True
-bot = commands.Bot(command_prefix=".", intents=intents)
+bot = commands.Bot(command_prefix=os.getenv("command_prefix", default="."), intents=intents)
 logger = logging.getLogger(__name__)
 impdip_server = 1201167737163104376
 bot_status_channel = 1284336328657600572

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -120,6 +120,9 @@ async def _handle_command(
     else:
         await send_message_and_file(**response)
 
+    if "file" in response:
+        response["file"] = f"{response["file"][:15]}..."
+
     elapsed = time.time() - start
     logger.debug(
         f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}' -> \n{response} | {elapsed}s"

--- a/bot/command.py
+++ b/bot/command.py
@@ -340,7 +340,7 @@ async def get_scoreboard(ctx: commands.Context, manager: Manager) -> dict[str, .
 
 @perms.gm("edit")
 async def edit(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
-    return {"message": parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id)) }
+    return parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id))
 
 
 @perms.gm("create a game")

--- a/bot/command.py
+++ b/bot/command.py
@@ -207,10 +207,8 @@ async def botsay(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     logger.info(f"{ctx.message.author.name} asked me to say '{content}' in {channel.name}")
     return {"channel": channel, "message": content}
 
-
+@perms.admin("send a GM announcement")
 async def announce(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
-    if not is_admin(ctx.message.author) and is_gm_channel(ctx.channel):
-        raise PermissionError("You cannot {description} because you are not a GM.")
     await ctx.message.add_reaction("👍")
     servers = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
     content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()

--- a/bot/command.py
+++ b/bot/command.py
@@ -373,10 +373,15 @@ async def delete_game(ctx: commands.Context, manager: Manager) -> dict[str, ...]
     return {"message": "Game deleted"}
 
 async def info(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
-    board = manager.get_board(ctx.guild.id)
-    message = ("Phase: " + str(board.phase) + "\nOrders are: " + ("Open" if board.orders_enabled else "Locked")
-               + "\nFog of War: " + str(board.fow))
-    return {"message": message }
+    try:
+        board = manager.get_board(ctx.guild.id)
+    except RuntimeError:
+        return {"message": "There is no existing game this this server."}
+    return {"message": ("Year: " + str(1642 + board.year) + "\n"
+               "Phase: " + str(board.phase) + "\n"
+               "Orders are: " + ("Open" if board.orders_enabled else "Locked") + "\n"
+               "Fog of War: " + str(board.fow))
+            }
 
 
 async def province_info(ctx: commands.Context, manager: Manager) -> dict[str, ...]:

--- a/bot/command.py
+++ b/bot/command.py
@@ -250,7 +250,7 @@ async def remove_order(player: Player | None, ctx: commands.Context, manager: Ma
 @perms.player("view orders")
 async def view_orders(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     try:
-        order_text = get_orders(manager.get_board(ctx.guild.id), player)
+        order_text = get_orders(manager.get_board(ctx.guild.id), player, ctx)
     except RuntimeError as err:
         logger.error(f"View_orders text failed in game with id: {ctx.guild.id}", exc_info=err)
         return {"message": "view_orders text failed", "embed_colour": ERROR_COLOUR}

--- a/bot/command.py
+++ b/bot/command.py
@@ -15,7 +15,8 @@ import bot.perms as perms
 from bot.config import is_bumble, temporary_bumbles
 from bot.parse_edit_state import parse_edit_state
 from bot.parse_order import parse_order, parse_remove_order
-from bot.utils import convert_svg_and_send_file, get_filtered_orders, get_orders, get_player_by_channel, get_player_by_channel, is_admin, send_message_and_file
+from bot.utils import (convert_svg_and_send_file, get_filtered_orders, get_orders,
+                       get_player_by_channel, get_player_by_channel, is_admin, send_message_and_file)
 from diplomacy.adjudicator.utils import svg_to_png
 from diplomacy.persistence import phase
 from diplomacy.persistence.db.database import get_connection
@@ -35,7 +36,7 @@ ping_text_choices = [
 ]
 
 
-async def ping(ctx: commands.Context, _: Manager) -> str:
+async def ping(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     response = "Beep Boop"
     if random.random() < 0.1:
         author = ctx.message.author
@@ -46,10 +47,10 @@ async def ping(ctx: commands.Context, _: Manager) -> str:
         if not name:
             name = author.name
         response = name + " " + random.choice(ping_text_choices) + content
-    return response
+    return {"message": response }
 
 
-async def bumble(ctx: commands.Context, manager: Manager) -> str:
+async def bumble(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     list_of_bumble = list("bumble")
     random.shuffle(list_of_bumble)
     word_of_bumble = "".join(list_of_bumble)
@@ -68,10 +69,10 @@ async def bumble(ctx: commands.Context, manager: Manager) -> str:
 
     board = manager.get_board(ctx.guild.id)
     board.fish -= 1
-    return f"**{word_of_bumble}**"
+    return {"message": f"**{word_of_bumble}**" }
 
 
-async def fish(ctx: commands.Context, manager: Manager) -> str:
+async def fish(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
     fish_num = random.randrange(0, 20)
 
@@ -138,17 +139,17 @@ async def fish(ctx: commands.Context, manager: Manager) -> str:
         temporary_bumbles.remove(ctx.author.name)
         fish_message = f"\n Your luck has run out! {fish_message}\nBumble is sad, you must once again prove your worth by Bumbling!"
 
-    return fish_message
+    return {"message": fish_message }
 
 
-async def phish(ctx: commands.Context, _: Manager) -> str:
+async def phish(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     message = "No! Phishing is bad!"
     if is_bumble(ctx.author.name):
         message = "Please provide your firstborn pet and your soul for a chance at winning your next game!"
-    return message
+    return {"message": message }
 
 
-async def cheat(ctx: commands.Context, manager: Manager) -> str:
+async def cheat(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     message = "Cheating is disabled for this user."
     author = ctx.message.author.name
     board = manager.get_board(ctx.guild.id)
@@ -168,10 +169,10 @@ async def cheat(ctx: commands.Context, manager: Manager) -> str:
             ]
         )
         message = f'Here\'s a helpful message I stole from the spectator chat: \n"{sample}"'
-    return message
+    return {"message": message }
 
 
-async def advice(ctx: commands.Context, _: Manager) -> str:
+async def advice(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     message = "You are not worthy of advice."
     if is_bumble(ctx.author.name):
         message = "Bumble suggests that you go fishing, although typically blasphemous, today is your lucky day!"
@@ -189,71 +190,75 @@ async def advice(ctx: commands.Context, _: Manager) -> str:
                 "The GMs suggest you input your orders so they don't need to hound you for them at the deadline.",
             ]
         )
-    return message
+    return {"message": message }
 
 
 @perms.gm("botsay")
-async def botsay(ctx: commands.Context, _: Manager) -> None:
+async def botsay(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     # noinspection PyTypeChecker
     if len(ctx.message.channel_mentions) == 0:
-        return
+        return {"message": "No Channel Given"}
     channel = ctx.message.channel_mentions[0]
     content = ctx.message.content
-    content = content.removeprefix(".botsay").replace(channel.mention, "").strip()
+    content = content.removeprefix(",botsay").replace(channel.mention, "").strip()
     if len(content) == 0:
-        return
+        return {"message": "No Message Given"}
     await ctx.message.add_reaction("👍")
     logger.info(f"{ctx.message.author.name} asked me to say '{content}' in {channel.name}")
-    await channel.send(content)
+    return {"channel": channel, "message": content}
 
 
-async def announce(ctx: commands.Context, servers: set[Guild | None]) -> None:
+async def announce(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     if not is_admin(ctx.message.author) and is_gm_channel(ctx.channel):
-        return
+        raise PermissionError("You cannot {description} because you are not a GM.")
     await ctx.message.add_reaction("👍")
+    servers = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
     content = ctx.message.content.removeprefix(".announce").strip()
     logger.info(f"{ctx.message.author.name} sent announcement '{content}'")
+    message = "Annoucement sent to:"
     for server in servers:
         if server is None:
             continue
         admin_chat_channel = next(channel for channel in server.channels if is_gm_channel(channel))
         if admin_chat_channel is None:
             continue
+        message += f"\n- {server.name}"
         await admin_chat_channel.send(f"__Announcement__\n{ctx.message.author.display_name} says:\n{content}")
+    return {"message": message}
 
 
 @perms.player("order")
-async def order(player: Player | None, ctx: commands.Context, manager: Manager) -> str:
+async def order(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     if player and not board.orders_enabled:
-        return "Orders locked! If you think this is an error, contact a GM."
+        return {"message": "Orders locked! If you think this is an error, contact a GM."}
 
-    return parse_order(ctx.message.content, player, board)
+    return {"message": parse_order(ctx.message.content, player, board) }
 
 
 @perms.player("remove orders")
-async def remove_order(player: Player | None, ctx: commands.Context, manager: Manager) -> str:
+async def remove_order(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     if player and not board.orders_enabled:
-        return "Orders locked! If you think this is an error, contact a GM."
+        return {"message": "Orders locked! If you think this is an error, contact a GM."}
 
-    return parse_remove_order(ctx.message.content, player, board)
+    return {"message": parse_remove_order(ctx.message.content, player, board) }
 
 
 @perms.player("view orders")
-async def view_orders(player: Player | None, ctx: commands.Context, manager: Manager) -> str:
+async def view_orders(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     try:
         order_text = get_orders(manager.get_board(ctx.guild.id), player)
     except RuntimeError as err:
         logger.error(f"View_orders text failed in game with id: {ctx.guild.id}", exc_info=err)
         order_text = "view_orders text failed"
-    return order_text
+    return {"message": order_text }
 
 
 @perms.player("view map")
-async def view_map(player: Player | None, ctx: commands.Context, manager: Manager) -> str | dict[str]:
+async def view_map(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     return_svg = player or ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() != "true"
     board = manager.get_board(ctx.guild.id)
 
@@ -264,11 +269,11 @@ async def view_map(player: Player | None, ctx: commands.Context, manager: Manage
             file, file_name = manager.draw_fow_players_moves_map(ctx.guild.id, player)
     except Exception as err:
         logger.error(f"View_orders map failed in game with id: {ctx.guild.id}", exc_info=err)
-        return "View_orders map failed"
+        return {"message": "View_orders map failed" }
     return {"message": "Map created successfully", "file": file, "file_name": file_name, "svg_to_png": return_svg}
 
 @perms.gm("adjudicate")
-async def adjudicate(ctx: commands.Context, manager: Manager) -> dict[str]:
+async def adjudicate(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     return_svg = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() != "true"
@@ -288,78 +293,80 @@ async def adjudicate(ctx: commands.Context, manager: Manager) -> dict[str]:
     return {"message": "Adjudication completed successfully", "file": file, "file_name": file_name, "svg_to_png": return_svg}
 
 @perms.gm("rollback")
-async def rollback(ctx: commands.Context, manager: Manager) -> dict[str]:
+async def rollback(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     return manager.rollback(ctx.guild.id)
 
 
 @perms.gm("reload")
-async def reload(ctx: commands.Context, manager: Manager) -> dict[str]:
+async def reload(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     return manager.reload(ctx.guild.id)
 
 
 @perms.gm("remove all orders")
-async def remove_all(ctx: commands.Context, manager: Manager) -> str:
+async def remove_all(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
     for unit in board.units:
         unit.order = None
 
     database = get_connection()
     database.save_order_for_units(board, board.units)
-    return "Successful"
+    return {"message": "Successful" }
 
 
-async def get_scoreboard(ctx: commands.Context, manager: Manager) -> str:
+async def get_scoreboard(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     if board.fow:
-        perms.gm_perms_check("get scoreboard")
+        perms.gm_perms_check(ctx, "get scoreboard")
 
     response = ""
     for player in board.get_players_by_score():
         response += f"\n__{player.name}__: {len(player.centers)} ({'+' if len(player.centers) - len(player.units) >= 0 else ''}{len(player.centers) - len(player.units)})"
-    return response
+    return {"message": response }
 
 
 @perms.gm("edit")
-async def edit(ctx: commands.Context, manager: Manager) -> dict[str]:
-    return parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id))
+async def edit(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
+    return {"message": parse_edit_state(ctx.message.content, manager.get_board(ctx.guild.id)) }
 
 
 @perms.gm("create a game")
-async def create_game(ctx: commands.Context, manager: Manager) -> str:
+async def create_game(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     gametype = ctx.message.content.removeprefix(".create_game")
     if gametype == "":
         gametype = "impdip.json"
     else:
         gametype = gametype.removeprefix(" ") + ".json"
-    return manager.create_game(ctx.guild.id, gametype)
+    return {"message": manager.create_game(ctx.guild.id, gametype) }
 
 
 @perms.gm("unlock orders")
-async def enable_orders(ctx: commands.Context, manager: Manager) -> str:
+async def enable_orders(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
     board.orders_enabled = True
-    return "Successful"
+    return {"message": "Successful" }
 
 
 @perms.gm("lock orders")
-async def disable_orders(ctx: commands.Context, manager: Manager) -> str:
+async def disable_orders(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
     board.orders_enabled = False
-    return "Successful"
+    return {"message": "Successful" }
 
 
 @perms.gm("delete the game")
-async def delete_game(ctx: commands.Context, manager: Manager) -> str:
+async def delete_game(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     manager.total_delete(ctx.guild.id)
-    return "Game deleted"
+    return {"message": "Game deleted"}
 
-async def info(ctx: commands.Context, manager: Manager) -> str:
+async def info(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
-    return "Phase: " + str(board.phase) + "\nOrders are: " + ("Open" if board.orders_enabled else "Locked") + "\nFog of War: " + str(board.fow)
+    message = ("Phase: " + str(board.phase) + "\nOrders are: " + ("Open" if board.orders_enabled else "Locked")
+               + "\nFog of War: " + str(board.fow))
+    return {"message": message }
 
 
-async def province_info(ctx: commands.Context, manager: Manager) -> str:
+async def province_info(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     if not board.orders_enabled:
@@ -368,17 +375,17 @@ async def province_info(ctx: commands.Context, manager: Manager) -> str:
  
     province_name = ctx.message.content.removeprefix(".province_info").strip()
     if not province_name:
-        raise ValueError("Usage: .province_info <province>")
+        return {"message": "Usage: .province_info <province>"}
     province, coast = board.get_province_and_coast(province_name)
     if province is None:
-        raise ValueError(f"Could not find province {province_name}")
+        return {"message": f"Could not find province {province_name}"}
 
 
     # FOW permissions
     if board.fow:
         player = perms.get_player_by_context(ctx, manager, "get province info")
         if player and not province in board.get_visible_provinces(player):
-            return f"Province {province.name} is not visible to you"
+            return {"message": f"Province {province.name} is not visible to you" }
     
     # fmt: off
     if not coast:
@@ -404,22 +411,22 @@ async def province_info(ctx: commands.Context, manager: Manager) -> str:
             "- " + \
             "\n- ".join(sorted([adjacent.name for adjacent in coast.get_adjacent_locations()])) + "\n"
     # fmt: on
-    return out
+    return {"message": out }
 
 
 @perms.player("view visible provinces")
-async def visible_provinces(player: Player | None, ctx: commands.Context, manager: Manager) -> str:
+async def visible_provinces(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     if not player or not board.fow:
-        return "This command only works for players in fog of war games."
+        return {"message": "This command only works for players in fog of war games."}
 
     visible_provinces = board.get_visible_provinces(player)
 
-    return ", ".join([x.name for x in visible_provinces])
+    return {"message": ", ".join([x.name for x in visible_provinces])}
 
 
-async def all_province_data(ctx: commands.Context, manager: Manager) -> str:
+async def all_province_data(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
     board = manager.get_board(ctx.guild.id)
 
     province_by_owner = defaultdict(list)
@@ -429,14 +436,14 @@ async def all_province_data(ctx: commands.Context, manager: Manager) -> str:
             owner = "None"
         province_by_owner[owner].append(province.name)
 
-    data = ""
+    message = ""
     for owner, provinces in province_by_owner.items():
-        data += f"{owner}: "
+        message += f"{owner}: "
         for province in provinces:
-            data += f"{province}, "
-        data += "\n\n"
+            message += f"{province}, "
+        message += "\n\n"
 
-    return data
+    return {"message": message }
 
 
 # needed due to async
@@ -457,13 +464,15 @@ async def publish_map(ctx: commands.Context, manager: Manager, name: str, map_ca
     guild_id = guild.id
     board = manager.get_board(guild_id)
 
+
     for category in guild.categories:
         if config.is_player_category(category.name):
             player_category = category
             break
 
     if not player_category:
-        return "No player category found"
+        # FIXME this shouldn't be an Error/this should propagate
+        raise RuntimeError("No player category found")
 
     name_to_player: dict[str, Player] = {}
     for player in board.players:
@@ -471,7 +480,7 @@ async def publish_map(ctx: commands.Context, manager: Manager, name: str, map_ca
 
     tasks = []
 
-    for channel in category.channels:
+    for channel in player_category.channels:
         player = get_player_by_channel(channel, manager, guild.id)
 
         if not player:
@@ -510,7 +519,7 @@ async def send_order_logs(ctx: commands.Context, manager: Manager):
     for player in board.players:
         name_to_player[player.name.lower()] = player
     
-    for channel in category.channels:
+    for channel in player_category.channels:
         player = get_player_by_channel(channel, manager, guild.id)
 
         if not player:
@@ -542,7 +551,7 @@ async def ping_players(ctx: commands.Context, manager: Manager):
             break
 
     if not player_category:
-        return "No player category found"
+        return {"message": "No player category found" }
 
     name_to_player: dict[str, Player] = {}
     player_to_role: dict[str, Role] = {}
@@ -560,11 +569,11 @@ async def ping_players(ctx: commands.Context, manager: Manager):
             player_to_role[player] = role
 
     if len(player_roles) == 0:
-        return "No player role found"
+        return {"message": "No player role found" }
 
     response = None
 
-    for channel in category.channels:
+    for channel in player_category.channels:
         player = get_player_by_channel(channel, manager, guild.id)
 
         if not player:
@@ -640,14 +649,14 @@ async def ping_players(ctx: commands.Context, manager: Manager):
             await channel.send(response)
             response = None
 
-    return "Successful"
+    return {"message": "Successful" }
 
-async def archive(ctx: commands.Context, _: Manager) -> str:
+async def archive(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     perms.gm_perms_check(ctx, "archive")
 
     categories = [channel.category for channel in ctx.message.channel_mentions]
     if not categories:
-        return "This channel is not part of a category."
+        return {"message": "This channel is not part of a category."}
 
     for category in categories:
         for channel in category.channels:
@@ -660,4 +669,5 @@ async def archive(ctx: commands.Context, _: Manager) -> str:
             # Apply the updated overwrites
             await channel.edit(overwrites=overwrites)
 
-    return f"The following catagories have been archived: {' '.join([catagory.name for catagory in categories])}"
+    message = f"The following catagories have been archived: {' '.join([catagory.name for catagory in categories])}"
+    return {"message": message }

--- a/bot/command.py
+++ b/bot/command.py
@@ -40,7 +40,7 @@ async def ping(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     response = "Beep Boop"
     if random.random() < 0.1:
         author = ctx.message.author
-        content = ctx.message.content.removeprefix(".ping")
+        content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
         if content == "":
             content = " nothing"
         name = author.nick
@@ -199,8 +199,8 @@ async def botsay(ctx: commands.Context, _: Manager) -> dict[str, ...]:
     if len(ctx.message.channel_mentions) == 0:
         return {"message": "No Channel Given"}
     channel = ctx.message.channel_mentions[0]
-    content = ctx.message.content
-    content = content.removeprefix(",botsay").replace(channel.mention, "").strip()
+    content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
+    content = content.replace(channel.mention, "").strip()
     if len(content) == 0:
         return {"message": "No Message Given"}
     await ctx.message.add_reaction("👍")
@@ -213,7 +213,7 @@ async def announce(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
         raise PermissionError("You cannot {description} because you are not a GM.")
     await ctx.message.add_reaction("👍")
     servers = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
-    content = ctx.message.content.removeprefix(".announce").strip()
+    content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
     logger.info(f"{ctx.message.author.name} sent announcement '{content}'")
     message = "Annoucement sent to:"
     for server in servers:
@@ -244,7 +244,9 @@ async def remove_order(player: Player | None, ctx: commands.Context, manager: Ma
     if player and not board.orders_enabled:
         return {"message": "Orders locked! If you think this is an error, contact a GM."}
 
-    return {"message": parse_remove_order(ctx.message.content, player, board) }
+    content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
+
+    return {"message": parse_remove_order(content, player, board) }
 
 
 @perms.player("view orders")
@@ -332,7 +334,7 @@ async def edit(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
 
 @perms.gm("create a game")
 async def create_game(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
-    gametype = ctx.message.content.removeprefix(".create_game")
+    gametype = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
     if gametype == "":
         gametype = "impdip.json"
     else:
@@ -373,7 +375,7 @@ async def province_info(ctx: commands.Context, manager: Manager) -> dict[str, ..
         perms.gm_context_check(ctx, "Orders locked! If you think this is an error, contact a GM.", 
             "You cannot use .province_info in a non-GM channel while orders are locked.")
  
-    province_name = ctx.message.content.removeprefix(".province_info").strip()
+    province_name = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
     if not province_name:
         return {"message": "Usage: .province_info <province>"}
     province, coast = board.get_province_and_coast(province_name)
@@ -537,7 +539,7 @@ async def ping_players(ctx: commands.Context, manager: Manager):
 
     player_category = None
 
-    timestamp = re.match(r"<t:(\d+):[a-zA-Z]>", ctx.message.content.removeprefix(".ping_players").strip())
+    timestamp = re.match(r"<t:(\d+):[a-zA-Z]>", ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip())
     if timestamp:
         timestamp = f"<t:{timestamp.group(1)}:R>"
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,3 +1,7 @@
+ERROR_COLOUR = "#FF0000"
+PARTIAL_ERROR_COLOUR = "#FF7700"
+
+
 # Capitalization is ignored in all definitions.
 # Please only insert lowercase names.
 def _is_member(string: str, group: set) -> bool:

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -18,7 +18,7 @@ _dislodge_unit_str = "dislodge unit"
 _make_units_claim_provinces_str = "make units claim provinces"
 
 
-def parse_edit_state(message: str, board: Board) -> dict[str]:
+def parse_edit_state(message: str, board: Board) -> dict[str, ...]:
     invalid: list[tuple[str, Exception]] = []
     commands = str.splitlines(message)
     if commands[0].strip() == ".edit":

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -250,7 +250,7 @@ def parse_remove_order(message: str, player_restriction: Player | None, board: B
     updated_units: set[Unit] = set()
     provinces_with_removed_builds: set[str] = set()
     for command in commands:
-        if command.strip() == ".remove_order":
+        if command.isspace():
             continue
         try:
             removed = _parse_remove_order(command, player_restriction, board)
@@ -284,10 +284,8 @@ def parse_remove_order(message: str, player_restriction: Player | None, board: B
 
 
 def _parse_remove_order(command: str, player_restriction: Player, board: Board) -> Unit | str:
-    command = command.lower()
+    command = command.lower().strip()
     keywords: list[str] = get_keywords(command)
-    if keywords[0] == ".remove order":
-        keywords = keywords[1:]
     location = keywords[0]
     province, coast = board.get_province_and_coast(location)
 

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -272,7 +272,11 @@ def parse_remove_order(message: str, player_restriction: Player | None, board: B
     if invalid:
         response = "The following order removals were invalid:"
         for command in invalid:
-            response += f"\n{command[0]} with error: {command[1]}"
+            response += f"\n- {command[0]} - {command[1]}"
+        if updated_units:
+            response += "\nOrders for the following units were removed:"
+            for unit in updated_units:
+                response += f"\n- {unit.province}"
     else:
         response = "Orders removed successfully."
 
@@ -311,14 +315,14 @@ def _parse_remove_order(command: str, player_restriction: Player, board: Board) 
             player = unit.player
             if player_restriction is None or player == player_restriction:
                 unit.order = None
-            return unit
+                return unit
         unit = province.dislodged_unit
         if unit is not None:
             player = unit.player
             if player_restriction is None or player == player_restriction:
                 unit.order = None
-            return unit
-        raise Exception(f"You control neither the unit nor dislodged unit in province {province.name}")
+                return unit
+        raise Exception(f"You control neither a unit nor a dislodged unit in {province.name}")
 
 
 def remove_player_order_for_location(board: Board, player: Player, location: Location) -> bool:

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -260,6 +260,27 @@ def parse_order(message: str, player_restriction: Player | None, board: Board) -
         paginator.add_line(line)
 
 
+
+    match board.phase.name:
+        case "Spring Moves":
+            date = datetime.date(1642 + board.year, 3, 21)
+        case "Spring Retreats":
+            date = datetime.date(1642 + board.year, 6, 7)
+
+        case "Fall Moves":
+            date = datetime.date(1642 + board.year, 9, 22)
+
+        case "Fall Retreats":
+            date = datetime.date(1642 + board.year, 12, 7)
+        case "Winter Builds":
+            date = datetime.date(1642 + board.year, 12, 22)
+        case _:
+            date = datetime.date(1642 + board.year, 1, 1)
+
+    time = datetime.datetime.combine(date, datetime.datetime.now().time())
+
+
+
     output = paginator.pages
     if errors:
         output[-1] += "\n" + "\n".join(errors)
@@ -270,12 +291,14 @@ def parse_order(message: str, player_restriction: Player | None, board: Board) -
         return {
             "messages": output,
             "embed_colour": embed_colour,
+            "time": time,
         }
     else:
         # output = "\n# Orders validated successfully.\n" + output
         return {
                 "title": "**Orders validated successfully.**",
                 "messages": output,
+                "time": time,
         }
 
 def parse_remove_order(message: str, player_restriction: Player | None, board: Board) -> dict[str, ...]:

--- a/bot/perms.py
+++ b/bot/perms.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 from discord.ext import commands
 
-from bot.utils import is_gm, is_gm_channel, get_player_by_role, is_player_channel, get_player_by_channel
+from bot.utils import is_gm, is_gm_channel, get_player_by_role, is_player_channel, get_player_by_channel, is_admin
 from diplomacy.persistence.manager import Manager
 from diplomacy.persistence.player import Player
 
@@ -45,6 +45,11 @@ def gm_context_check(ctx: commands.Context, not_gm: str, not_channel):
 def gm_perms_check(ctx, description):
     gm_context_check(ctx, f"You cannot {description} because you are not a GM.", f"You cannot {description} in a non-GM channel.")
 
+def admin_perms_check(ctx, description):
+    if not is_admin(ctx.message.author):
+        raise PermissionError(f"You cannot {description} as you are not an admin")
+    if not is_gm_channel(ctx.channel):
+        raise PermissionError(f"You cannot {description} in a non-GM channel.")
 
 def gm(description: str = "run this command"):
     def gm_check(
@@ -58,3 +63,16 @@ def gm(description: str = "run this command"):
         return f
 
     return gm_check
+
+def admin(description: str = "run this command"):
+    def admin_check(
+        function: Callable[[commands.Context, Manager], tuple[str, str | None]]
+    ) -> Callable[[commands.Context, Manager], tuple[str, str | None]]:
+
+        def f(ctx: commands.Context, manager: Manager) -> tuple[str, str | None]:
+            admin_perms_check(ctx, description)
+            return function(ctx, manager)
+
+        return f
+
+    return admin_check

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -129,13 +129,25 @@ async def send_message_and_file(
         channel: commands.Context.channel,
         title: str = None,
         message: str = None,
+        messages: [str] = None,
         embed_colour: str = "#fc71c4",
         file: str = None,
         file_name: str = None,
         file_in_embed: bool = True,
         **_
 ):
-    embeds = []
+    if messages:
+        embeds = [Embed(
+                title=title,
+                description=message,
+                colour=Colour.from_str(embed_colour),
+            ) for message in messages[:-1]]
+        # ensure only first embed has title
+        if len(messages) >= 2:
+            title = None
+        message = messages[-1]
+    else:
+        embeds = []
     if message:
         while 0 < len(message):
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -134,6 +134,7 @@ async def send_message_and_file(
         file: str = None,
         file_name: str = None,
         file_in_embed: bool = True,
+        time: datetime.datetime = None,
         **_
 ):
     if messages:
@@ -208,7 +209,11 @@ async def send_message_and_file(
         icon_url="https://cdn.discordapp.com/icons/1201167737163104376/f78e67edebfdefad8f3ee057ad658acd.webp"
                  "?size=96&quality=lossless"
     )
-    embeds[-1].timestamp = datetime.datetime.now()
+
+    if time is None:
+        datetime.datetime.now()
+
+    embeds[-1].timestamp = time
 
     await channel.send(embeds=embeds, file=discord_file)
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -136,7 +136,9 @@ async def send_message_and_file(channel: commands.Context.channel, message: str,
                 cutoff = message.rfind("\n", 0, discord_embed_description_limit)
                 # otherwise split at limit
                 if cutoff == -1:
-                    cutoff = discord_embed_description_limit
+                    cutoff = message.rfind(" ", 0, discord_embed_description_limit)
+                    if cutoff == -1:
+                        cutoff = 0
 
             embed = Embed(
                 description=message[:cutoff],

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -124,7 +124,7 @@ def get_unit_type(command: str) -> UnitType | None:
         return UnitType.FLEET
     return None
 
-async def send_message_and_file(channel: commands.Context.channel, message: str, file: str, file_name: str):
+async def send_message_and_file(channel: commands.Context.channel, message: str = "", file: str = None, file_name: str = None, **_kwargs):
     embeds = []
     if message:
         while 0 < len(message):
@@ -142,7 +142,7 @@ async def send_message_and_file(channel: commands.Context.channel, message: str,
 
             embed = Embed(
                 description=message[:cutoff],
-                colour=Colour.from_str("#c410ee"),
+                colour=Colour.from_str("#fc71c4"),
             )
 
             # check that embed totals arent over the total message embed character limit.
@@ -265,7 +265,7 @@ def get_filtered_orders(board: Board, player_restriction: Player) -> str:
     
 svg_export_limit = asyncio.Semaphore(int(os.getenv("simultaneous_svg_exports_limit")))
 
-async def convert_svg_and_send_file(channel, message, file, file_name):
+async def convert_svg_and_send_file(response: dict[str, ...]):
     async with svg_export_limit:
-        file, file_name = await svg_to_png(file, file_name)
-        await send_message_and_file(channel, message, file, file_name)
+        response["file"], response["file_name"] = await svg_to_png(response["file"], response["file_name"])
+        await send_message_and_file(**response)

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -138,7 +138,7 @@ async def send_message_and_file(channel: commands.Context.channel, message: str,
                 if cutoff == -1:
                     cutoff = message.rfind(" ", 0, discord_embed_description_limit)
                     if cutoff == -1:
-                        cutoff = 0
+                        cutoff = discord_embed_description_limit
 
             embed = Embed(
                 description=message[:cutoff],

--- a/diplomacy/persistence/manager.py
+++ b/diplomacy/persistence/manager.py
@@ -57,7 +57,7 @@ class Manager:
         logger.info(f"manager.draw_moves_map.{server_id}.{elapsed}s")
         return svg, file_name
 
-    def adjudicate(self, server_id: int) -> tuple[str, str]:
+    def adjudicate(self, server_id: int) -> None:
         start = time.time()
 
         # mapper = Mapper(self._boards[server_id])
@@ -120,7 +120,7 @@ class Manager:
         logger.info(f"manager.draw_fow_moves_map.{server_id}.{elapsed}s")
         return svg, file_name
 
-    def rollback(self, server_id: int) -> dict[str]:
+    def rollback(self, server_id: int) -> dict[str, ...]:
         logger.info(f"Rolling back in server {server_id}")
         board = self._boards[server_id]
         # TODO: what happens if we're on the first phase?
@@ -141,7 +141,7 @@ class Manager:
         file, file_name = mapper.draw_current_map()
         return {"message": message, "file": file, "file_name": file_name, "svg_to_png": False}
 
-    def reload(self, server_id: int) -> dict[str]:
+    def reload(self, server_id: int) -> dict[str, ...]:
         logger.info(f"Reloading server {server_id}")
         board = self._boards[server_id]
 


### PR DESCRIPTION
`bot.utils.send_message_and_file` sends message content in embed descriptions instead of message content.

Embed descriptions have a higher limit of 4096 characters increasing how many orders you need to break the codeblock in `.view_orders`.