### PR TITLE
More assorted QOL changes

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -63,7 +63,8 @@ async def on_ready():
 @bot.before_invoke
 async def before_any_command(ctx):
     logger.debug(f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}'")
-
+    # People input apostrophes that don't match what the province names are, we can catch all of that here
+    ctx.message.content = re.sub(r"[‘’`´′‛]", "'", ctx.message.content)
     # mark the message as seen
     await ctx.message.add_reaction("👍")
 
@@ -102,9 +103,6 @@ async def _handle_command(
     ctx: commands.Context,
 ) -> None:
     start = time.time()
-
-    # People input apostrophes that don't match what the province names are, we can catch all of that here
-    ctx.message.content = re.sub(r"[‘’`´′‛]", "'", ctx.message.content)
 
     response = await function(ctx, manager)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -7,7 +7,7 @@ import random
 from dotenv.main import load_dotenv
 
 from bot.config import ERROR_COLOUR
-from bot.utils import convert_svg_and_send_file, send_message_and_file
+from bot.utils import send_message_and_file
 load_dotenv()
 
 import discord
@@ -111,17 +111,7 @@ async def _handle_command(
     if "channel" not in response:
         response["channel"] = ctx.channel
 
-    if "svg_to_png" not in response:
-        response["svg_to_png"] = False
-
-    # don't embed non svgs
-    if not response["svg_to_png"]:
-        response["file_in_embed"] = False
-
-    if response["svg_to_png"]:
-        await convert_svg_and_send_file(response)
-    else:
-        await send_message_and_file(**response)
+    await send_message_and_file(**response)
 
     if "file" in response:
         response["file"] = f"{response['file'][:15]}..."

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -122,13 +122,8 @@ async def _handle_command(
 
     response = await function(ctx, manager)
 
-    if "channel" not in response:
-        response["channel"] = ctx.channel
-
-    await send_message_and_file(**response)
-
-    if "file" in response:
-        response["file"] = f"{response['file'][:15]}..."
+    if response:
+        raise Exception("function returned something yikes")
 
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -156,6 +156,11 @@ async def botsay(ctx: commands.Context) -> None:
 async def announce(ctx: commands.Context) -> None:
     await command.announce(ctx, manager)
 
+@bot.command(hidden=True)
+async def servers(ctx: commands.Context) -> None:
+    await command.servers(ctx, manager)
+
+
 
 @bot.command(
     brief="Submits orders; there must be one and only one order per line.",

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,8 +2,6 @@ import logging
 import os
 import re
 import datetime
-import time
-from typing import Callable, Awaitable
 import random
 from dotenv.main import load_dotenv
 
@@ -115,58 +113,46 @@ async def on_command_error(ctx, error):
             raise error
 
 
-async def _handle_command(
-    function: Callable[[commands.Context, Manager], Awaitable[dict[str, ...]]],
-    ctx: commands.Context,
-) -> None:
-
-    response = await function(ctx, manager)
-
-    if response:
-        raise Exception("function returned something yikes")
-
-
-
 @bot.command(help="Checks bot listens and responds.")
 async def ping(ctx: commands.Context) -> None:
-    await _handle_command(command.ping, ctx)
+    await command.ping(ctx, manager)
 
 
 # @bot.command(hidden=True)
 async def bumble(ctx: commands.Context) -> None:
-    await _handle_command(command.bumble, ctx)
+    await command.bumble(ctx, manager)
 
 
 # @bot.command(hidden=True)
 async def fish(ctx: commands.Context) -> None:
     await ctx.message.add_reaction("🐟")
-    await _handle_command(command.fish, ctx)
+    await command.fish(ctx, manager)
 
 
 # @bot.command(hidden=True)
 async def phish(ctx: commands.Context) -> None:
     await ctx.message.add_reaction("🐟")
-    await _handle_command(command.phish, ctx)
+    await command.phish(ctx, manager)
 
 
 # @bot.command(hidden=True)
 async def cheat(ctx: commands.Context) -> None:
-    await _handle_command(command.cheat, ctx)
+    await command.cheat(ctx, manager)
 
 
 # @bot.command(hidden=True)
 async def advice(ctx: commands.Context) -> None:
-    await _handle_command(command.advice, ctx)
+    await command.advice(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def botsay(ctx: commands.Context) -> None:
-    await _handle_command(command.botsay, ctx)
+    await command.botsay(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def announce(ctx: commands.Context) -> None:
-    await _handle_command(command.announce, ctx)
+    await command.announce(ctx, manager)
 
 
 @bot.command(
@@ -182,7 +168,7 @@ async def announce(ctx: commands.Context) -> None:
 
 )
 async def order(ctx: commands.Context) -> None:
-    await _handle_command(command.order, ctx)
+    await command.order(ctx, manager)
 
 
 @bot.command(
@@ -192,7 +178,7 @@ async def order(ctx: commands.Context) -> None:
     aliases=["remove", "rm", "removeorders"]
 )
 async def remove_order(ctx: commands.Context) -> None:
-    await _handle_command(command.remove_order, ctx)
+    await command.remove_order(ctx, manager)
 
 
 @bot.command(
@@ -202,14 +188,14 @@ async def remove_order(ctx: commands.Context) -> None:
     aliases=["v", "view", "vieworders", "view-orders"],
 )
 async def view_orders(ctx: commands.Context) -> None:
-    await _handle_command(command.view_orders, ctx)
+    await command.view_orders(ctx, manager)
 
 @bot.command(
     brief="Sends order all orders ",
     description="For GM: Sends orders from previous phase to #orders-log",
 )
 async def publish_orders(ctx: commands.Context) -> None:
-    await _handle_command(command.publish_orders, ctx)
+    await command.publish_orders(ctx, manager)
 
 @bot.command(
     brief="Outputs the current map with submitted orders.",
@@ -221,7 +207,7 @@ async def publish_orders(ctx: commands.Context) -> None:
     aliases=["viewmap", "vm"],
 )
 async def view_map(ctx: commands.Context) -> None:
-    await _handle_command(command.view_map, ctx)
+    await command.view_map(ctx, manager)
 
 
 @bot.command(brief="Adjudicates the game and outputs the moves and results maps.",
@@ -231,22 +217,22 @@ async def view_map(ctx: commands.Context) -> None:
     """
 )
 async def adjudicate(ctx: commands.Context) -> None:
-    await _handle_command(command.adjudicate, ctx)
+    await command.adjudicate(ctx, manager)
 
 
 @bot.command(brief="Rolls back to the previous game state.")
 async def rollback(ctx: commands.Context) -> None:
-    await _handle_command(command.rollback, ctx)
+    await command.rollback(ctx, manager)
 
 
 @bot.command(brief="Reloads the current board with what is in the DB")
 async def reload(ctx: commands.Context) -> None:
-    await _handle_command(command.reload, ctx)
+    await command.reload(ctx, manager)
 
 
 @bot.command(brief="Outputs the scoreboard.", description="Outputs the scoreboard.")
 async def scoreboard(ctx: commands.Context) -> None:
-    await _handle_command(command.get_scoreboard, ctx)
+    await command.get_scoreboard(ctx, manager)
 
 
 @bot.command(
@@ -268,12 +254,12 @@ async def scoreboard(ctx: commands.Context) -> None:
     * make_units_claim_provinces {True|(False) - whether or not to claim SCs}""",
 )
 async def edit(ctx: commands.Context) -> None:
-    await _handle_command(command.edit, ctx)
+    await command.edit(ctx, manager)
 
 
 @bot.command(brief="Clears all players orders.")
 async def remove_all(ctx: commands.Context) -> None:
-    await _handle_command(command.remove_all, ctx)
+    await command.remove_all(ctx, manager)
 
 
 @bot.command(
@@ -283,7 +269,7 @@ async def remove_all(ctx: commands.Context) -> None:
     aliases=["lock"]
 )
 async def lock_orders(ctx: commands.Context) -> None:
-    await _handle_command(command.disable_orders, ctx)
+    await command.disable_orders(ctx, manager)
 
 
 @bot.command(
@@ -291,7 +277,7 @@ async def lock_orders(ctx: commands.Context) -> None:
     aliases=["unlock"]
 )
 async def unlock_orders(ctx: commands.Context) -> None:
-    await _handle_command(command.enable_orders, ctx)
+    await command.enable_orders(ctx, manager)
 
 
 @bot.command(
@@ -299,7 +285,7 @@ async def unlock_orders(ctx: commands.Context) -> None:
     aliases=["i"]
 )
 async def info(ctx: commands.Context) -> None:
-    await _handle_command(command.info, ctx)
+    await command.info(ctx, manager)
 
 
 @bot.command(
@@ -307,16 +293,16 @@ async def info(ctx: commands.Context) -> None:
     aliases=["province"],
 )
 async def province_info(ctx: commands.Context) -> None:
-    await _handle_command(command.province_info, ctx)
+    await command.province_info(ctx, manager)
 
 @bot.command(brief="outputs the provinces you can see")
 async def visible_info(ctx: commands.Context) -> None:
-    await _handle_command(command.visible_provinces, ctx)
+    await command.visible_provinces(ctx, manager)
 
 
 @bot.command(brief="outputs all provinces per owner")
 async def all_province_data(ctx: commands.Context) -> None:
-    await _handle_command(command.all_province_data, ctx)
+    await command.all_province_data(ctx, manager)
 
 
 @bot.command(
@@ -324,7 +310,7 @@ async def all_province_data(ctx: commands.Context) -> None:
     description="Create a game of Imp Dip and output the map. (there are no other variant options at this time)",
 )
 async def create_game(ctx: commands.Context) -> None:
-    await _handle_command(command.create_game, ctx)
+    await command.create_game(ctx, manager)
 
 
 @bot.command(
@@ -333,7 +319,7 @@ async def create_game(ctx: commands.Context) -> None:
     * .archive [link to any channel in category]""",
 )
 async def archive(ctx: commands.Context) -> None:
-    await _handle_command(command.archive, ctx)
+    await command.archive(ctx, manager)
 
 @bot.command(
     brief="pings players who don't have the expected number of orders.",
@@ -344,11 +330,11 @@ async def archive(ctx: commands.Context) -> None:
     * .ping_players <timestamp>
     """)
 async def ping_players(ctx: commands.Context) -> None:
-    await _handle_command(command.ping_players, ctx)
+    await command.ping_players(ctx, manager)
 
 @bot.command(brief="permanently deletes a game, cannot be undone")
 async def delete_game(ctx: commands.Context) -> None:
-    await _handle_command(command.delete_game, ctx)
+    await command.delete_game(ctx, manager)
 
 
 def run():

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -61,8 +61,10 @@ async def on_ready():
 @bot.before_invoke
 async def before_any_command(ctx):
     logger.debug(f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}'")
+
     # People input apostrophes that don't match what the province names are, we can catch all of that here
-    ctx.message.content = re.sub(r"[‘’`´′‛]", "'", ctx.message.content)
+    # ctx.message.content = re.sub(r"[‘’`´′‛]", "'", ctx.message.content)
+
     # mark the message as seen
     await ctx.message.add_reaction("👍")
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -386,7 +386,7 @@ async def publish_orders(ctx: commands.Context, manager: Manager) -> None:
 
 @perms.player("view map")
 async def view_map(player: Player | None, ctx: commands.Context, manager: Manager) -> None:
-    return_svg = not player and ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() != "true"
+    return_svg = not player and ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() not in ("true", "t", "svg", "s")
     board = manager.get_board(ctx.guild.id)
 
     try:

--- a/bot/command.py
+++ b/bot/command.py
@@ -311,7 +311,6 @@ async def view_map(player: Player | None, ctx: commands.Context, manager: Manage
     log_command(logger, ctx, message=f"Generated map for {board.phase.name} {str(1642 + board.year)}")
     return {
         "title": f"{board.phase.name} {str(1642 + board.year)}",
-        "message": "Map created successfully",
         "file": file,
         "file_name": file_name,
         "convert_svg": return_svg,

--- a/bot/command.py
+++ b/bot/command.py
@@ -15,7 +15,7 @@ import bot.perms as perms
 from bot.config import is_bumble, temporary_bumbles, ERROR_COLOUR
 from bot.parse_edit_state import parse_edit_state
 from bot.parse_order import parse_order, parse_remove_order
-from bot.utils import (convert_svg_and_send_file, get_filtered_orders, get_orders,
+from bot.utils import (get_filtered_orders, get_orders,
                        get_orders_log, get_player_by_channel, is_admin, send_message_and_file,
                        get_role_by_player)
 from diplomacy.adjudicator.utils import svg_to_png
@@ -282,7 +282,7 @@ async def publish_orders(ctx: commands.Context, manager: Manager) -> dict[str, .
 
 @perms.player("view map")
 async def view_map(player: Player | None, ctx: commands.Context, manager: Manager) -> dict[str, ...]:
-    return_svg = player or ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() != "true"
+    return_svg = not player and ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower() != "true"
     board = manager.get_board(ctx.guild.id)
 
     try:
@@ -298,7 +298,7 @@ async def view_map(player: Player | None, ctx: commands.Context, manager: Manage
         "message": "Map created successfully",
         "file": file,
         "file_name": file_name,
-        "svg_to_png": return_svg,
+        "convert_svg": return_svg,
         "file_in_embed": False,
     }
 
@@ -328,7 +328,7 @@ async def adjudicate(ctx: commands.Context, manager: Manager) -> dict[str, ...]:
         "message": "Adjudication has completed successfully",
         "file": file,
         "file_name": file_name,
-        "svg_to_png": return_svg,
+        "convert_svg": return_svg,
         "file_in_embed": False,
     }
 
@@ -546,7 +546,7 @@ async def publish_map(ctx: commands.Context, manager: Manager, name: str, map_ca
 
     await asyncio.gather(*tasks)
 
-# save at least one svg slot for others
+# if possible save one svg slot for others
 fow_export_limit = asyncio.Semaphore(max(int(os.getenv("simultaneous_svg_exports_limit")) - 1, 1))
 
 async def map_publish_task(map_maker, channel, message):

--- a/bot/command.py
+++ b/bot/command.py
@@ -492,7 +492,14 @@ async def all_province_data(ctx: commands.Context, manager: Manager) -> dict[str
 
     message = ""
     for owner, provinces in province_by_owner.items():
-        message += f"{owner}: "
+        if owner is None:
+            player_name = "None"
+        elif (player_role := get_role_by_player(owner, ctx.guild.roles)) is not None:
+            player_name = player_role.mention
+        else:
+            player_name = owner
+
+        message += f"{player_name}: "
         for province in provinces:
             message += f"{province}, "
         message += "\n\n"

--- a/bot/command.py
+++ b/bot/command.py
@@ -6,7 +6,7 @@ from random import randrange
 from typing import Callable
 
 from black.trans import defaultdict
-from discord import Role
+from discord import Role, HTTPException, NotFound
 from discord import PermissionOverwrite
 from discord.ext import commands
 
@@ -219,10 +219,10 @@ async def botsay(ctx: commands.Context, _: Manager) -> None:
 @perms.admin("send a GM announcement")
 async def announce(ctx: commands.Context, manager: Manager) -> None:
     await ctx.message.add_reaction("👍")
-    servers = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
+    guilds = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
     content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
     message = "Annoucement sent to:"
-    for server in servers:
+    for server in guilds:
         if server is None:
             continue
         admin_chat_channel = next(channel for channel in server.channels if is_gm_channel(channel))
@@ -230,9 +230,34 @@ async def announce(ctx: commands.Context, manager: Manager) -> None:
             continue
         message += f"\n- {server.name}"
         await admin_chat_channel.send(f"__Announcement__\n{ctx.message.author.display_name} says:\n{content}")
-    log_command(logger, ctx, f"Sent Announcement into {len(servers)} servers")
+    log_command(logger, ctx, f"Sent Announcement into {len(guilds)} servers")
     await send_message_and_file(channel=ctx.channel, title=message)
 
+@perms.admin("list servers")
+async def servers(ctx: commands.Context, manager: Manager) -> None:
+    guilds = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
+    message = ""
+    for server in guilds:
+        if server is None:
+            continue
+        admin_chat_channel = next(channel for channel in server.channels if is_gm_channel(channel))
+        if admin_chat_channel is None:
+            continue
+        channels = server.channels
+        if len(channels) == 0:
+            message += f"\n- {server.name} - Could not find a channel for invite"
+            continue
+        try:
+            invite = await channels[0].create_invite(max_age=300)
+        except (HTTPException, NotFound):
+            message += f"\n- {server.name} - Could not create invite"
+            continue
+
+        message += f"\n- [{server.name}](<{invite.url}>)"
+    log_command(logger, ctx, f"Sent Announcement into {len(guilds)} servers")
+    await send_message_and_file(channel=ctx.channel,
+                                title=f"{len(guilds)} Servers",
+                                message=message)
 
 @perms.player("order")
 async def order(player: Player | None, ctx: commands.Context, manager: Manager) -> None:

--- a/bot/command.py
+++ b/bot/command.py
@@ -212,9 +212,14 @@ async def botsay(ctx: commands.Context, _: Manager) -> None:
                                     message="No Message Given",
                                     embed_colour=ERROR_COLOUR)
         return
-    await ctx.message.add_reaction("👍")
+
+    message = await send_message_and_file(channel=channel, message=content)
     log_command(logger, ctx, f"Sent Message into #{channel.name}")
-    await send_message_and_file(channel=ctx.channel, title=content)
+    await send_message_and_file(channel=ctx.channel,
+                                title=f"Sent Message",
+                                message=message.jump_url,
+                                )
+
 
 @perms.admin("send a GM announcement")
 async def announce(ctx: commands.Context, manager: Manager) -> None:

--- a/bot/command.py
+++ b/bot/command.py
@@ -223,7 +223,6 @@ async def botsay(ctx: commands.Context, _: Manager) -> None:
 
 @perms.admin("send a GM announcement")
 async def announce(ctx: commands.Context, manager: Manager) -> None:
-    await ctx.message.add_reaction("👍")
     guilds = {ctx.bot.get_guild(server_id) for server_id in manager.list_servers()}
     content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
     message = "Annoucement sent to:"

--- a/bot/command.py
+++ b/bot/command.py
@@ -248,8 +248,10 @@ async def order(player: Player | None, ctx: commands.Context, manager: Manager) 
     message = parse_order(ctx.message.content, player, board)
     if "title" in message:
         log_command(logger, ctx, message=message["title"])
-    else:
+    elif "message" in message:
         log_command(logger, ctx, message=message["message"][:100])
+    elif "messages" in message and len(message["messages"]) > 0:
+        log_command(logger, ctx, message=message["messages"][0][:100])
     await send_message_and_file(channel=ctx.channel, **message)
 
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -250,9 +250,13 @@ async def announce(ctx: commands.Context, manager: Manager) -> None:
                     break
             else:
                 server_roles.append(role_name)
-        await admin_chat_channel.send(f"__Announcement__\n{ctx.message.author.display_name} says:\n{content.format(*server_roles)}")
+
+        await admin_chat_channel.send(("||" + "{}" * len(server_roles) + "||").format(*server_roles))
+        await send_message_and_file(channel=admin_chat_channel,
+                                    title="Admin Announcement",
+                                    message=content.format(*server_roles))
     log_command(logger, ctx, f"Sent Announcement into {len(ctx.bot.guilds)} servers")
-    await send_message_and_file(channel=ctx.channel, title=f"Annoucement sent to {len(ctx.bot.guilds)} servers:",message=message)
+    await send_message_and_file(channel=ctx.channel, title=f"Announcement sent to {len(ctx.bot.guilds)} servers:",message=message)
 
 @perms.admin("list servers")
 async def servers(ctx: commands.Context, manager: Manager) -> None:

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -1,4 +1,6 @@
 import string
+
+from bot.config import ERROR_COLOUR
 from bot.utils import get_unit_type, get_keywords
 from diplomacy.adjudicator.mapper import Mapper
 from diplomacy.persistence import phase
@@ -29,16 +31,26 @@ def parse_edit_state(message: str, board: Board) -> dict[str, ...]:
         except Exception as error:
             invalid.append((command, error))
 
+    embed_colour = None
     if invalid:
-        response = "The following commands were invalid:"
+        response_title = "Error"
+        response_body = "The following commands were invalid:"
         for command in invalid:
-            response += f"\n{command[0]} with error: {command[1]}"
+            response_body += f"\n{command[0]} with error: {command[1]}"
+        embed_colour = ERROR_COLOUR
     else:
-        response = "Commands validated successfully. Results map updated."
+        response_title = "Commands validated successfully. Results map updated."
+        response_body = ""
 
     file, file_name = Mapper(board).draw_current_map()
 
-    return {"message": response, "file": file, "file_name": file_name}
+    return {
+        "title": response_title,
+        "message": response_body,
+        "file": file,
+        "file_name": file_name,
+        "embed_colour": embed_colour
+    }
 
 
 def _parse_command(command: str, board: Board) -> None:

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -38,7 +38,7 @@ def parse_edit_state(message: str, board: Board) -> dict[str, ...]:
 
     file, file_name = Mapper(board).draw_current_map()
 
-    return {"message": response, "file": file, "file_name": file_name, "svg_to_png": False}
+    return {"message": response, "file": file, "file_name": file_name}
 
 
 def _parse_command(command: str, board: Board) -> None:

--- a/bot/parse_edit_state.py
+++ b/bot/parse_edit_state.py
@@ -1,6 +1,6 @@
 import string
 
-from bot.config import ERROR_COLOUR
+from bot.config import ERROR_COLOUR, PARTIAL_ERROR_COLOUR
 from bot.utils import get_unit_type, get_keywords
 from diplomacy.adjudicator.mapper import Mapper
 from diplomacy.persistence import phase
@@ -36,13 +36,20 @@ def parse_edit_state(message: str, board: Board) -> dict[str, ...]:
         response_title = "Error"
         response_body = "The following commands were invalid:"
         for command in invalid:
-            response_body += f"\n{command[0]} with error: {command[1]}"
-        embed_colour = ERROR_COLOUR
+            response_body += f"\n`{command[0]}` with error: {command[1]}"
+
+        if len(invalid) == len(commands):
+            embed_colour = ERROR_COLOUR
+        else:
+            embed_colour = PARTIAL_ERROR_COLOUR
     else:
         response_title = "Commands validated successfully. Results map updated."
         response_body = ""
 
-    file, file_name = Mapper(board).draw_current_map()
+    if len(invalid) < len(commands):
+        file, file_name = Mapper(board).draw_current_map()
+    else:
+        file, file_name = None, None
 
     return {
         "title": response_title,

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -259,24 +259,6 @@ def parse_order(message: str, player_restriction: Player | None, board: Board) -
     for line in orderoutput:
         paginator.add_line(line)
 
-    match board.phase.name:
-        case "Spring Moves":
-            date = datetime.date(1642 + board.year, 3, 21)
-        case "Spring Retreats":
-            date = datetime.date(1642 + board.year, 6, 7)
-
-        case "Fall Moves":
-            date = datetime.date(1642 + board.year, 9, 22)
-
-        case "Fall Retreats":
-            date = datetime.date(1642 + board.year, 12, 7)
-        case "Winter Builds":
-            date = datetime.date(1642 + board.year, 12, 22)
-        case _:
-            date = datetime.date(1642 + board.year, 1, 1)
-
-    time = datetime.datetime.combine(date, datetime.datetime.now().time())
-
     output = paginator.pages
     if errors:
         output[-1] += "\n" + "\n".join(errors)
@@ -287,13 +269,11 @@ def parse_order(message: str, player_restriction: Player | None, board: Board) -
         return {
             "messages": output,
             "embed_colour": embed_colour,
-            "time": time,
         }
     else:
         return {
                 "title": "**Orders validated successfully.**",
                 "messages": output,
-                "time": time,
         }
 
 def parse_remove_order(message: str, player_restriction: Player | None, board: Board) -> dict[str, ...]:

--- a/bot/parse_order.py
+++ b/bot/parse_order.py
@@ -298,7 +298,7 @@ def parse_order(message: str, player_restriction: Player | None, board: Board) -
 
 def parse_remove_order(message: str, player_restriction: Player | None, board: Board) -> dict[str, ...]:
     invalid: list[tuple[str, Exception]] = []
-    commands = str.splitlines(message)
+    commands = message.splitlines()
     updated_units: set[Unit] = set()
     provinces_with_removed_builds: set[str] = set()
     for command in commands:
@@ -338,16 +338,14 @@ def parse_remove_order(message: str, player_restriction: Player | None, board: B
 
 def _parse_remove_order(command: str, player_restriction: Player, board: Board) -> Unit | str:
     command = command.lower().strip()
-    keywords: list[str] = get_keywords(command)
-    location = keywords[0]
-    province, coast = board.get_province_and_coast(location)
+    province, coast = board.get_province_and_coast(command)
 
     if phase.is_builds(board.phase):
         # remove build order
         player = province.owner
         if player_restriction is not None and player != player_restriction:
             raise PermissionError(
-                f"{player_restriction.name} does not control the unit in {location} which belongs to {player.name}"
+                f"{player_restriction.name} does not control the unit in {command} which belongs to {player.name}"
             )
 
         remove_player_order_for_location(board, player, province)

--- a/bot/perms.py
+++ b/bot/perms.py
@@ -48,8 +48,6 @@ def gm_perms_check(ctx, description):
 def admin_perms_check(ctx, description):
     if not is_admin(ctx.message.author):
         raise PermissionError(f"You cannot {description} as you are not an admin")
-    if not is_gm_channel(ctx.channel):
-        raise PermissionError(f"You cannot {description} in a non-GM channel.")
 
 def gm(description: str = "run this command"):
     def gm_check(

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -7,7 +7,7 @@ import time
 import zipfile
 import discord
 from typing import List, Tuple
-from discord import Embed, Colour, Guild
+from discord import Embed, Colour, Guild, Message
 from discord.abc import GuildChannel
 from discord.ext import commands
 from discord.ext.commands import Context
@@ -211,7 +211,7 @@ async def send_message_and_file(
         fields: List[Tuple[str, str]] = None,
         convert_svg: bool = False,
         **_
-) -> None:
+) -> Message:
     if not embed_colour:
         embed_colour = "#fc71c4"
     if convert_svg and file and file_name:
@@ -332,7 +332,7 @@ async def send_message_and_file(
 
     embeds[-1].timestamp = time
 
-    await channel.send(embeds=embeds, file=discord_file)
+    return await channel.send(embeds=embeds, file=discord_file)
 
 
 def get_orders(board: Board, player_restriction: Player | None, ctx: Context, fields: bool = False) -> str | List[Tuple[str, str]]:

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -213,7 +213,8 @@ async def send_message_and_file(
         file: str = None,
         file_name: str = None,
         file_in_embed: bool = None,
-        time: datetime.datetime = None,
+        footer_content: str = None,
+        footer_datetime: datetime.datetime = None,
         fields: List[Tuple[str, str]] = None,
         convert_svg: bool = False,
         **_
@@ -336,17 +337,14 @@ async def send_message_and_file(
         )))):
             embeds[-1].set_image(url=f"attachment://{discord_file.filename.replace(' ', '_')}")
 
+    if footer_datetime or footer_content:
+        embeds[-1].set_footer(
+            text=footer_content,
+            icon_url="https://cdn.discordapp.com/icons/1201167737163104376/f78e67edebfdefad8f3ee057ad658acd.webp"
+                     "?size=96&quality=lossless"
+        )
 
-    embeds[-1].set_footer(
-        text="DiploGM",
-        icon_url="https://cdn.discordapp.com/icons/1201167737163104376/f78e67edebfdefad8f3ee057ad658acd.webp"
-                 "?size=96&quality=lossless"
-    )
-
-    if time is None:
-        datetime.datetime.now()
-
-    embeds[-1].timestamp = time
+        embeds[-1].timestamp = footer_datetime
 
     return await channel.send(embeds=embeds, file=discord_file)
 

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -53,7 +53,13 @@ discord_embed_description_limit = 4096
 discord_embed_total_limit = 6000
 
 def is_admin(author: commands.Context.author) -> bool:
-    return author.name in ["eebopmasch", "icecream_guy", "_bumble", "thisisflare", "eelisha"]
+    return author.id in [
+        1217203346511761428,    # eebop
+        332252245259190274,     # Icecream Guy
+        169995316680982528,     # Bumble
+        450636420558618625,     # Flare
+        490633966974533640,     # Elle
+    ]
 
 
 def is_gm(author: commands.Context.author) -> bool:

--- a/config/impdip.1.2.json
+++ b/config/impdip.1.2.json
@@ -1,5 +1,5 @@
 {
-    "name": "Imp Dip",
+    "name": "Imperial Diplomacy B1.2",
     "file": "assets/impdip.1.2.svg",
     "svg config": {
         "land_layer": "layer6",

--- a/config/impdip1.1.json
+++ b/config/impdip1.1.json
@@ -1,5 +1,5 @@
 {
-    "name": "Imp Dip",
+    "name": "Imperial Diplomacy B1.1",
     "file": "assets/impdip.1.1.svg",
     "svg config": {
         "land_layer": "layer6",

--- a/config/impdipfow.json
+++ b/config/impdipfow.json
@@ -1,5 +1,5 @@
 {
-    "name": "Imp Dip",
+    "name": "Imperial Diplomacy B1.2 - Fog of War",
     "file": "assets/impdipfow.svg",
     "svg config": {
         "land_layer": "layer6",

--- a/diplomacy/adjudicator/utils.py
+++ b/diplomacy/adjudicator/utils.py
@@ -2,27 +2,28 @@ import asyncio
 from subprocess import PIPE
 import os
 
-
+svg_export_limit = asyncio.Semaphore(int(os.getenv("simultaneous_svg_exports_limit")))
 async def svg_to_png(svg: bytes, file_name: str):
-    # https://gitlab.com/inkscape/inkscape/-/issues/4716
-    os_env = os.environ.copy()
-    os_env["SELF_CALL"] = "xxx"
-    p = await asyncio.create_subprocess_shell("inkscape --pipe --export-type=png --export-dpi=200", stdout=PIPE, stdin=PIPE, stderr=PIPE, env=os_env)
-    data, error = await p.communicate(input=svg)
+    async with svg_export_limit:
+        # https://gitlab.com/inkscape/inkscape/-/issues/4716
+        os_env = os.environ.copy()
+        os_env["SELF_CALL"] = "xxx"
+        p = await asyncio.create_subprocess_shell("inkscape --pipe --export-type=png --export-dpi=200", stdout=PIPE, stdin=PIPE, stderr=PIPE, env=os_env)
+        data, error = await p.communicate(input=svg)
 
-    # Stupid inkscape error fix, not good but works
-    # Inkscape can throw warnings in stdout, this should remove those warnings, leaving us with a valid png
+        # Stupid inkscape error fix, not good but works
+        # Inkscape can throw warnings in stdout, this should remove those warnings, leaving us with a valid png
 
-    # This should indicate the start of the png, see https://www.w3.org/TR/2003/REC-PNG-20031110/#5PNG-file-signature
-    png_start = b'\x89PNG\r\n\x1a\n'
-
-    if data[:8] != png_start:
-        data = data[data.find(png_start):]
+        # This should indicate the start of the png, see https://www.w3.org/TR/2003/REC-PNG-20031110/#5PNG-file-signature
+        png_start = b'\x89PNG\r\n\x1a\n'
 
         if data[:8] != png_start:
-            print(data)
-            print(error)
-            raise RuntimeError("Something went wrong with making the png.")
+            data = data[data.find(png_start):]
 
-    base = os.path.splitext(file_name)[0]
-    return bytes(data), base + ".png"
+            if data[:8] != png_start:
+                print(data)
+                print(error)
+                raise RuntimeError("Something went wrong with making the png.")
+
+        base = os.path.splitext(file_name)[0]
+        return bytes(data), base + ".png"

--- a/diplomacy/persistence/board.py
+++ b/diplomacy/persistence/board.py
@@ -43,6 +43,8 @@ class Board:
         # FIXME: This should not be raising exceptions many places already assume it returns None on failure.
         # TODO: (BETA) we build this everywhere, let's just have one live on the Board on init
         # we ignore capitalization because this is primarily used for user input
+        # People input apostrophes that don't match what the province names are
+        name = re.sub(r"[‘’`´′‛]", "'", name)
         name = name.lower()
         name_to_province: dict[str, Province] = {}
         name_to_coast: dict[str, Coast] = {}
@@ -103,6 +105,8 @@ class Board:
         return matches
 
     def get_location(self, name: str) -> Location:
+        # People input apostrophes that don't match what the province names are
+        name = re.sub(r"[‘’`´′‛]", "'", name)
         province, coast = self.get_province_and_coast(name)
 
         if coast:

--- a/diplomacy/persistence/board.py
+++ b/diplomacy/persistence/board.py
@@ -40,6 +40,7 @@ class Board:
         return province
 
     def get_province_and_coast(self, name: str) -> tuple[Province, Coast | None]:
+        # FIXME: This should not be raising exceptions many places already assume it returns None on failure.
         # TODO: (BETA) we build this everywhere, let's just have one live on the Board on init
         # we ignore capitalization because this is primarily used for user input
         name = name.lower()

--- a/diplomacy/persistence/manager.py
+++ b/diplomacy/persistence/manager.py
@@ -139,7 +139,7 @@ class Manager:
 
         message = f"Rolled back to {old_board.get_phase_and_year_string()}"
         file, file_name = mapper.draw_current_map()
-        return {"message": message, "file": file, "file_name": file_name, "svg_to_png": False}
+        return {"message": message, "file": file, "file_name": file_name}
 
     def get_previous_board(self, server_id: int) -> Board | None:
         board = self._boards[server_id]
@@ -164,4 +164,4 @@ class Manager:
 
         message = f"Reloaded board for phase {loaded_board.get_phase_and_year_string()}"
         file, file_name = mapper.draw_current_map()
-        return {"message": message, "file": file, "file_name": file_name, "svg_to_png": False}
+        return {"message": message, "file": file, "file_name": file_name}


### PR DESCRIPTION
- Removed the function `_handle_command()`
- now, only provinces receiveapostrophe fix 
- admin commands can be run in any channel
- `.vm` doesnt have the success message, only the current phase
- `.all_province_data` now mentions roles of controlling players
- `send_message_and_file()` now converts to jpg if png to big
- `send_message_and_file()` now splits up fields and messages correctly between embeds and messages to avoid discords limits. This means `.publish_orders` won't break when 1 player has too many provinces _cough cough_ Austria vs Qing
- .edit will not generate a map if all commands failed
- `.servers` shows all the servers the bot is in and tries to generate invite links
- `.servers` and `.announce` show the phase of displayed servers
- `.botsay` posts a link to the sent message to the invoker
- `is_admin()` checks against ids instead of usernames
- `.announce` posts messages in embeds
- `.remove_order` can accept spaces in province names
- `.vm true` now also accepts `svg`, `s` & `t`