### PR TITLE
Mutual servers command

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -76,6 +76,9 @@ async def on_ready():
 
 @bot.before_invoke
 async def before_any_command(ctx):
+    if isinstance(ctx.channel, discord.DMChannel):
+        return
+
     logger.debug(
         f"[{ctx.guild.name}][#{ctx.channel.name}]({ctx.message.author.name}) - '{ctx.message.content}'"
     )
@@ -231,7 +234,9 @@ class SpecView(discord.ui.View):
                 f"Accept response sent to {self.member.mention}!", ephemeral=True
             )
         except:
-            logger.warning(f"Unable to send a message to direct message. The user might have DMs blocked.")
+            logger.warning(
+                f"Unable to send a message to direct message. The user might have DMs blocked."
+            )
         await self.member.add_roles(self.power_role, self.spec_role)
 
         out = f"[SPECTATOR LOG] {self.member.mention} approved for power {self.power_role.mention}"
@@ -259,7 +264,9 @@ class SpecView(discord.ui.View):
                 f"Reject response sent to {self.member.mention}!", ephemeral=True
             )
         except:
-            logger.warning(f"Unable to send a message to direct message. The user might have DMs blocked.")
+            logger.warning(
+                f"Unable to send a message to direct message. The user might have DMs blocked."
+            )
 
         out = f"[SPECTATOR LOG] {self.member.mention} rejected for power {self.power_role.mention}"
         await self.admin_channel.send(out)
@@ -463,105 +470,75 @@ async def spec(interaction: discord.Interaction, power_role: discord.Role):
     )
 
 
+@bot.command(help="Returns all shared guilds between DiploGM and user.")
+@gm_only("find mutuals with user")
+async def membership(ctx: commands.Context) -> None:
+    await command.membership(ctx, manager)
+
+
 @bot.command(help="Checks bot listens and responds.")
 async def ping(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.ping(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def pelican(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.pelican(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def bumble(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.bumble(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def fish(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await ctx.message.add_reaction("🐟")
     await command.fish(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def phish(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await ctx.message.add_reaction("🐟")
     await command.phish(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def cheat(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.cheat(ctx, manager)
 
 
 @bot.command(hidden=True)
 async def advice(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.advice(ctx, manager)
 
 
 @bot.command(hidden=True)
 @gm_only("botsay")
 async def botsay(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.botsay(ctx, manager)
 
 
 @bot.command(hidden=True)
 @admin_only("send a GM announcement")
 async def announce(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.announce(ctx, manager)
 
 
 @bot.command(hidden=True)
 @admin_only("list servers")
 async def servers(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.servers(ctx, manager)
 
 
 @bot.command(hidden=True)
 @admin_only("allocate roles to user(s)")
 async def bulk_allocate_role(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.bulk_allocate_role(ctx, manager)
 
 
 @bot.command(brief="Shows global fish leaderboard")
 async def global_leaderboard(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.global_leaderboard(ctx, manager)
 
 
@@ -577,9 +554,6 @@ async def global_leaderboard(ctx: commands.Context) -> None:
     aliases=["o", "orders"],
 )
 async def order(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.order(ctx, manager)
 
 
@@ -590,9 +564,6 @@ async def order(ctx: commands.Context) -> None:
     aliases=["remove", "rm", "removeorders"],
 )
 async def remove_order(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.remove_order(ctx, manager)
 
 
@@ -604,9 +575,6 @@ async def remove_order(ctx: commands.Context) -> None:
     aliases=["v", "view", "vieworders", "view-orders"],
 )
 async def view_orders(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.view_orders(ctx, manager)
 
 
@@ -616,9 +584,6 @@ async def view_orders(ctx: commands.Context) -> None:
 )
 @gm_only("publish orders")
 async def publish_orders(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.publish_orders(ctx, manager)
 
 
@@ -630,9 +595,6 @@ async def publish_orders(ctx: commands.Context) -> None:
 )
 @gm_only("publish fow moves")
 async def publish_fow_moves(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.publish_fow_moves(ctx, manager)
 
 
@@ -644,9 +606,6 @@ async def publish_fow_moves(ctx: commands.Context) -> None:
 )
 @gm_only("send fow order logs")
 async def publish_fow_orders(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.publish_fow_order_logs(ctx, manager)
 
 
@@ -664,9 +623,6 @@ async def publish_fow_orders(ctx: commands.Context) -> None:
     aliases=["viewmap", "vm"],
 )
 async def view_map(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.view_map(ctx, manager)
 
 
@@ -681,9 +637,6 @@ async def view_map(ctx: commands.Context) -> None:
     aliases=["viewcurrent", "vc"],
 )
 async def view_current(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.view_current(ctx, manager)
 
 
@@ -692,9 +645,6 @@ async def view_current(ctx: commands.Context) -> None:
     aliases=["g"],
 )
 async def view_gui(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.view_gui(ctx, manager)
 
 
@@ -710,27 +660,18 @@ async def view_gui(ctx: commands.Context) -> None:
 )
 @gm_only("adjudicate")
 async def adjudicate(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.adjudicate(ctx, manager)
 
 
 @bot.command(brief="Rolls back to the previous game state.")
 @gm_only("rollback")
 async def rollback(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.rollback(ctx, manager)
 
 
 @bot.command(brief="Reloads the current board with what is in the DB")
 @gm_only("reload")
 async def reload(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.reload(ctx, manager)
 
 
@@ -741,9 +682,6 @@ async def reload(ctx: commands.Context) -> None:
     aliases=["leaderboard"],
 )
 async def scoreboard(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.get_scoreboard(ctx, manager)
 
 
@@ -772,18 +710,12 @@ async def scoreboard(ctx: commands.Context) -> None:
 )
 @gm_only("edit")
 async def edit(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.edit(ctx, manager)
 
 
 @bot.command(brief="Clears all players orders.")
 @gm_only("remove all orders")
 async def remove_all(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.remove_all(ctx, manager)
 
 
@@ -795,26 +727,17 @@ async def remove_all(ctx: commands.Context) -> None:
 )
 @gm_only("lock orders")
 async def lock_orders(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.disable_orders(ctx, manager)
 
 
 @bot.command(brief="re-enables orders", aliases=["unlock"])
 @gm_only("unlock orders")
 async def unlock_orders(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.enable_orders(ctx, manager)
 
 
 @bot.command(brief="outputs information about the current game", aliases=["i"])
 async def info(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.info(ctx, manager)
 
 
@@ -823,9 +746,6 @@ async def info(ctx: commands.Context) -> None:
     aliases=["province"],
 )
 async def province_info(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.province_info(ctx, manager)
 
 
@@ -834,33 +754,21 @@ async def province_info(ctx: commands.Context) -> None:
     aliases=["player"],
 )
 async def player_info(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.player_info(ctx, manager)
 
 
 @bot.command(brief="outputs the provinces you can see")
 async def visible_info(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.visible_provinces(ctx, manager)
 
 
 @bot.command(brief="publicize void for chaos")
 async def publicize(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.publicize(ctx, manager)
 
 
 @bot.command(brief="outputs all provinces per owner")
 async def all_province_data(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.all_province_data(ctx, manager)
 
 
@@ -870,9 +778,6 @@ async def all_province_data(ctx: commands.Context) -> None:
 )
 @gm_only("create a game")
 async def create_game(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.create_game(ctx, manager)
 
 
@@ -883,9 +788,6 @@ async def create_game(ctx: commands.Context) -> None:
 )
 @gm_only("archive")
 async def archive(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.archive(ctx, manager)
 
 
@@ -895,9 +797,6 @@ async def archive(ctx: commands.Context) -> None:
 )
 @gm_only("create blitz comms channels")
 async def blitz(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.blitz(ctx, manager)
 
 
@@ -919,26 +818,17 @@ async def blitz(ctx: commands.Context) -> None:
 )
 @gm_only("ping players")
 async def ping_players(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.ping_players(ctx, manager)
 
 
 @bot.command(brief="permanently deletes a game, cannot be undone")
 @gm_only("delete the game")
 async def delete_game(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.delete_game(ctx, manager)
 
 
 @bot.command(brief="Changes your nickname")
 async def nick(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.nick(ctx, manager)
 
 
@@ -949,10 +839,7 @@ async def nick(ctx: commands.Context) -> None:
     Usage: .record_spec @User @Nation""",
 )
 @gm_only("record a spec")
-async def record_spec(ctx: commands.Context, manager: Manager) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
+async def record_spec(ctx: commands.Context) -> None:
     await command.record_spec(ctx, manager)
 
 
@@ -960,19 +847,13 @@ async def record_spec(ctx: commands.Context, manager: Manager) -> None:
     brief="Backlogs the approval for all current Country Spectators", hidden=True
 )
 @gm_only("backlog spectators")
-async def backlog_specs(ctx: commands.Context, manager: Manager) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
+async def backlog_specs(ctx: commands.Context) -> None:
     await command.backlog_specs(ctx, manager)
 
 
 @bot.command(hidden=True)
 @admin_only("Execute arbitrary code")
 async def exec_py(ctx: commands.Context) -> None:
-    if isinstance(ctx.channel, discord.DMChannel):
-        return
-
     await command.exec_py(ctx, manager)
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -9,7 +9,7 @@ from discord import Forbidden
 from dotenv.main import load_dotenv
 
 from bot.config import ERROR_COLOUR
-from bot.perms import admin_only, CommandPermissionError, gm_only
+from bot.perms import admin_only, CommandPermissionError, gm_only, mod_only
 from bot.utils import send_message_and_file
 
 load_dotenv()
@@ -471,7 +471,7 @@ async def spec(interaction: discord.Interaction, power_role: discord.Role):
 
 
 @bot.command(help="Returns all shared guilds between DiploGM and user.")
-@gm_only("find mutuals with user")
+@mod_only("find mutuals with user")
 async def membership(ctx: commands.Context) -> None:
     await command.membership(ctx, manager)
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 from discord.utils import find as discord_find
 
 from bot import config
+from bot.bot import impdip_server
 import bot.perms as perms
 from bot.config import is_bumble, temporary_bumbles, ERROR_COLOUR
 from bot.parse_edit_state import parse_edit_state
@@ -35,6 +36,7 @@ from bot.utils import (
     get_player_by_channel,
     get_player_by_name,
     is_gm,
+    is_moderator,
     send_message_and_file,
     get_role_by_player,
     log_command,

--- a/bot/command.py
+++ b/bot/command.py
@@ -1881,12 +1881,12 @@ async def membership(ctx: commands.Context, _: Manager) -> None:
 
     member = ctx.message.mentions[0]
 
-    out = ""
+    out = f"Number of servers: {len(member.mutual_guilds)}\n---\n"
     for shared in member.mutual_guilds:
         out += f"{shared.name}\n"
 
     await send_message_and_file(
-        channel=ctx.channel, title=f"Mutual servers with {member.mention}", message=out
+        channel=ctx.channel, title=f"Mutual servers with {member.name}\n{member.mention}", message=out
     )
 
 

--- a/bot/command.py
+++ b/bot/command.py
@@ -134,7 +134,6 @@ async def fish(ctx: commands.Context, manager: Manager) -> None:
     time_now = time.time()
     delta_t = time_now - board.fish_pop["time"]
 
-
     board.fish_pop["time"] = time_now
     board.fish_pop["fish_pop"] = odeint(
         fish_pop_model, board.fish_pop["fish_pop"], [0, delta_t], args=args
@@ -340,13 +339,15 @@ async def botsay(ctx: commands.Context, _: Manager) -> None:
 async def announce(ctx: commands.Context, manager: Manager) -> None:
     guilds_with_games = manager.list_servers()
     content = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
-    content = re.sub(r'<@&[0-9]{16,20}>', r'{}', content)
+    content = re.sub(r"<@&[0-9]{16,20}>", r"{}", content)
     roles = list(map(lambda role: role.name, ctx.message.role_mentions))
     message = ""
     for server in ctx.bot.guilds:
         if server is None:
             continue
-        admin_chat_channel = next(channel for channel in server.channels if is_gm_channel(channel))
+        admin_chat_channel = next(
+            channel for channel in server.channels if is_gm_channel(channel)
+        )
         if admin_chat_channel is None:
             message += f"\n- ~~{server.name}~~ Couldn't find admin channel"
 
@@ -367,17 +368,19 @@ async def announce(ctx: commands.Context, manager: Manager) -> None:
                 server_roles.append(role_name)
 
         if len(server_roles) > 0:
-            await admin_chat_channel.send(("||" + "{}" * len(server_roles) + "||").format(*server_roles))
+            await admin_chat_channel.send(
+                ("||" + "{}" * len(server_roles) + "||").format(*server_roles)
+            )
         await send_message_and_file(
             channel=admin_chat_channel,
             title="Admin Announcement",
-            message=content.format(*server_roles)
+            message=content.format(*server_roles),
         )
     log_command(logger, ctx, f"Sent Announcement into {len(ctx.bot.guilds)} servers")
     await send_message_and_file(
         channel=ctx.channel,
         title=f"Announcement sent to {len(ctx.bot.guilds)} servers:",
-        message=message
+        message=message,
     )
 
 
@@ -422,7 +425,6 @@ async def servers(ctx: commands.Context, manager: Manager) -> None:
     )
 
 
-
 async def bulk_allocate_role(ctx: commands.Context, manager: Manager) -> None:
     guild = ctx.guild
     if guild is None:
@@ -433,7 +435,11 @@ async def bulk_allocate_role(ctx: commands.Context, manager: Manager) -> None:
     roles = ctx.message.role_mentions
     role_names = list(map(lambda r: r.name, roles))
     if len(roles) == 0:
-        await send_message_and_file(channel=ctx.channel, title="Error", message="No roles were supplied to allocate. Please include a role mention in the command.")
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Error",
+            message="No roles were supplied to allocate. Please include a role mention in the command.",
+        )
         return
 
     # parse usernames from trailing contents
@@ -544,25 +550,44 @@ async def remove_order(
 
 
 @perms.player("view orders")
-async def view_orders(player: Player | None, ctx: commands.Context, manager: Manager) -> None:
-    arguments = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip().lower().split()
+async def view_orders(
+    player: Player | None, ctx: commands.Context, manager: Manager
+) -> None:
+    arguments = (
+        ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with)
+        .strip()
+        .lower()
+        .split()
+    )
     subset = "missing" if {"missing", "miss", "m"} & set(arguments) else None
-    subset = "submitted" if {"submitted", "submit", "sub", "s"} & set(arguments) else subset
+    subset = (
+        "submitted" if {"submitted", "submit", "sub", "s"} & set(arguments) else subset
+    )
 
     try:
         board = manager.get_board(ctx.guild.id)
         order_text = get_orders(board, player, ctx, subset=subset)
     except RuntimeError as err:
         logger.error(err, exc_info=True)
-        log_command(logger, ctx, message=f"Failed for an unknown reason", level=logging.ERROR)
-        await send_message_and_file(channel=ctx.channel,
-                                    title="Unknown Error: Please contact your local bot dev",
-                                    embed_colour=ERROR_COLOUR)
+        log_command(
+            logger, ctx, message=f"Failed for an unknown reason", level=logging.ERROR
+        )
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Unknown Error: Please contact your local bot dev",
+            embed_colour=ERROR_COLOUR,
+        )
         return
-    log_command(logger, ctx, message=f"Success - generated orders for {board.phase.name} {board.get_year_str()}")
-    await send_message_and_file(channel=ctx.channel,
-                                title=f"{board.phase.name} {board.get_year_str()}",
-                                message=order_text)
+    log_command(
+        logger,
+        ctx,
+        message=f"Success - generated orders for {board.phase.name} {board.get_year_str()}",
+    )
+    await send_message_and_file(
+        channel=ctx.channel,
+        title=f"{board.phase.name} {board.get_year_str()}",
+        message=order_text,
+    )
 
 
 async def publish_orders(ctx: commands.Context, manager: Manager) -> None:
@@ -826,7 +851,6 @@ async def view_gui(
     )
 
 
-
 async def adjudicate(ctx: commands.Context, manager: Manager) -> None:
     board = manager.get_board(ctx.guild.id)
 
@@ -870,7 +894,6 @@ async def adjudicate(ctx: commands.Context, manager: Manager) -> None:
         convert_svg=return_svg,
         file_in_embed=False,
     )
-
 
 
 async def rollback(ctx: commands.Context, manager: Manager) -> None:
@@ -957,7 +980,6 @@ async def get_scoreboard(ctx: commands.Context, manager: Manager) -> None:
     )
 
 
-
 async def edit(ctx: commands.Context, manager: Manager) -> None:
     edit_commands = ctx.message.content.removeprefix(
         ctx.prefix + ctx.invoked_with
@@ -1007,7 +1029,6 @@ async def delete_game(ctx: commands.Context, manager: Manager) -> None:
     await send_message_and_file(channel=ctx.channel, title="Deleted game")
 
 
-
 async def info(ctx: commands.Context, manager: Manager) -> None:
     try:
         board = manager.get_board(ctx.guild.id)
@@ -1017,16 +1038,24 @@ async def info(ctx: commands.Context, manager: Manager) -> None:
             channel=ctx.channel, title="There is no game this this server."
         )
         return
-    log_command(logger, ctx, message=f"Displayed info - {board.get_year_str()}|"
-                                     f"{str(board.phase)}|{str(board.datafile)}|"
-                                     f"{'Open' if board.orders_enabled else 'Locked'}" )
-    await send_message_and_file(channel=ctx.channel,
-                                message=(f"Year: {board.get_year_str()}\n"
-                                         f"Phase: {str(board.phase)}\n"
-                                         f"Orders are {'Open' if board.orders_enabled else 'Locked'}\n"
-                                         f"Game Type: {str(board.datafile)}\n"
-                                         f"Chaos: {':white_check_mark:' if board.is_chaos() else ':x:'}\n"
-                                         f"Fog of War: {':white_check_mark:' if board.fow else ':x:'}"))
+    log_command(
+        logger,
+        ctx,
+        message=f"Displayed info - {board.get_year_str()}|"
+        f"{str(board.phase)}|{str(board.datafile)}|"
+        f"{'Open' if board.orders_enabled else 'Locked'}",
+    )
+    await send_message_and_file(
+        channel=ctx.channel,
+        message=(
+            f"Year: {board.get_year_str()}\n"
+            f"Phase: {str(board.phase)}\n"
+            f"Orders are {'Open' if board.orders_enabled else 'Locked'}\n"
+            f"Game Type: {str(board.datafile)}\n"
+            f"Chaos: {':white_check_mark:' if board.is_chaos() else ':x:'}\n"
+            f"Fog of War: {':white_check_mark:' if board.fow else ':x:'}"
+        ),
+    )
 
 
 async def province_info(ctx: commands.Context, manager: Manager) -> None:
@@ -1036,11 +1065,13 @@ async def province_info(ctx: commands.Context, manager: Manager) -> None:
         perms.assert_gm_only(
             ctx,
             "You cannot use .province_info in a non-GM channel while orders are locked.",
-            non_gm_alt="Orders locked! If you think this is an error, contact a GM."
+            non_gm_alt="Orders locked! If you think this is an error, contact a GM.",
         )
         return
 
-    province_name = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
+    province_name = ctx.message.content.removeprefix(
+        ctx.prefix + ctx.invoked_with
+    ).strip()
     if not province_name:
         log_command(logger, ctx, message=f"No province given")
         await send_message_and_file(
@@ -1100,7 +1131,6 @@ async def province_info(ctx: commands.Context, manager: Manager) -> None:
     await send_message_and_file(channel=ctx.channel, title=province.name, message=out)
 
 
-
 async def player_info(ctx: commands.Context, manager: Manager) -> None:
     board = manager.get_board(ctx.guild.id)
 
@@ -1108,11 +1138,13 @@ async def player_info(ctx: commands.Context, manager: Manager) -> None:
         perms.assert_gm_only(
             ctx,
             "You cannot use .province_info in a non-GM channel while orders are locked.",
-            non_gm_alt= "Orders locked! If you think this is an error, contact a GM."
+            non_gm_alt="Orders locked! If you think this is an error, contact a GM.",
         )
         return
 
-    player_name = ctx.message.content.removeprefix(ctx.prefix + ctx.invoked_with).strip()
+    player_name = ctx.message.content.removeprefix(
+        ctx.prefix + ctx.invoked_with
+    ).strip()
     if not player_name:
         log_command(logger, ctx, message=f"No province given")
         await send_message_and_file(
@@ -1298,8 +1330,10 @@ async def publish_fow_current(ctx: commands.Context, manager: Manager):
     )
 
 
-
-async def publish_fow_moves(ctx: commands.Context, manager: Manager,):
+async def publish_fow_moves(
+    ctx: commands.Context,
+    manager: Manager,
+):
     board = manager.get_board(ctx.guild.id)
 
     if not board.fow:
@@ -1385,7 +1419,6 @@ async def map_publish_task(map_maker, channel, message):
         )
 
 
-
 async def publish_fow_order_logs(ctx: commands.Context, manager: Manager):
     player_category = None
 
@@ -1426,7 +1459,6 @@ async def publish_fow_order_logs(ctx: commands.Context, manager: Manager):
 
 
 async def ping_players(ctx: commands.Context, manager: Manager) -> None:
-
     player_categories: list[CategoryChannel] = []
 
     timestamp = re.match(
@@ -1761,17 +1793,28 @@ async def nick(ctx: commands.Context, manager: Manager) -> None:
         channel=ctx.channel, message=f"Nickname updated to `{prefix + name}`"
     )
 
+
 async def record_spec(ctx: commands.Context, manager: Manager) -> None:
-    guild = ctx.guild 
+    guild = ctx.guild
     if not guild:
         return
 
     if len(ctx.message.role_mentions) == 0:
-        await send_message_and_file(channel=ctx.channel, title="Error", message="Did not mention a nation.", embed_colour=ERROR_COLOUR)
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Error",
+            message="Did not mention a nation.",
+            embed_colour=ERROR_COLOUR,
+        )
         return
 
     if len(ctx.message.mentions) == 0:
-        await send_message_and_file(channel=ctx.channel, title="Error", message="Did not mention a user.", embed_colour=ERROR_COLOUR)
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Error",
+            message="Did not mention a user.",
+            embed_colour=ERROR_COLOUR,
+        )
         return
 
     user = ctx.message.mentions[0]
@@ -1780,10 +1823,9 @@ async def record_spec(ctx: commands.Context, manager: Manager) -> None:
     power_role = ctx.message.role_mentions[0]
     power_id = power_role.id
 
-    out = manager.save_spec_request(guild.id, user_id, power_id)
-    await send_message_and_file(
-        channel=ctx.channel, message=out
-    )
+    out = manager.save_spec_request(guild.id, user_id, power_id, override=True)
+    await send_message_and_file(channel=ctx.channel, message=out)
+
 
 async def backlog_specs(ctx: commands.Context, manager: Manager) -> None:
     guild = ctx.guild
@@ -1792,17 +1834,23 @@ async def backlog_specs(ctx: commands.Context, manager: Manager) -> None:
 
     cspec = discord_find(lambda r: r.name == "Country Spectator", guild.roles)
     if cspec is None:
-        await send_message_and_file(channel=ctx.channel, title="Error", message="There is no Country Spectator role in this server.")
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Error",
+            message="There is no Country Spectator role in this server.",
+        )
         return
 
     out = ""
     for member in guild.members:
         if cspec not in member.roles:
             continue
-        
+
         power_role = None
         for role in member.roles:
-            if discord_find(lambda c: c.name == f"{role.name.lower()}-orders", guild.text_channels):
+            if discord_find(
+                lambda c: c.name == f"{role.name.lower()}-orders", guild.text_channels
+            ):
                 power_role = role
                 break
 
@@ -1812,13 +1860,42 @@ async def backlog_specs(ctx: commands.Context, manager: Manager) -> None:
         result = manager.save_spec_request(guild.id, member.id, power_role.id)
         out += f"{member.mention} -> {power_role.mention}: {result}\n"
 
-    await send_message_and_file(channel=ctx.channel, title="Spectator Backlog Results", message=out)
+    await send_message_and_file(
+        channel=ctx.channel, title="Spectator Backlog Results", message=out
+    )
+
+
+async def membership(ctx: commands.Context, _: Manager) -> None:
+    guild = ctx.guild
+    if not guild:
+        return
+
+    if len(ctx.message.mentions) == 0:
+        await send_message_and_file(
+            channel=ctx.channel,
+            title="Error",
+            message="Did not mention a user.",
+            embed_colour=ERROR_COLOUR,
+        )
+        return
+
+    member = ctx.message.mentions[0]
+
+    out = ""
+    for shared in member.mutual_guilds:
+        out += f"{shared.name}\n"
+
+    await send_message_and_file(
+        channel=ctx.channel, title=f"Mutual servers with {member.mention}", message=out
+    )
+
 
 class ContainedPrinter:
     def __init__(self):
         self.text = ""
+
     def __call__(self, *args):
-        self.text += ' '.join(map(str, args)) + '\n'
+        self.text += " ".join(map(str, args)) + "\n"
 
 
 async def exec_py(ctx: commands.Context, manager: Manager) -> None:

--- a/bot/config.py
+++ b/bot/config.py
@@ -9,6 +9,16 @@ PARTIAL_ERROR_COLOUR = "#FF7700"
 def _is_member(string: str, group: set) -> bool:
     return string.lower() in group
 
+# Discord roles which are allowed access to moderator commands
+_mod_roles: set[str] = {
+    "executive",
+    "admin",
+    "moderators",
+    "moderator",
+}
+
+def is_mod_role(role_name: str) -> bool:
+    return _is_member(role_name, _mod_roles)
 
 # Discord roles which are allowed full access to bot commands
 _gm_roles: set[str] = {

--- a/bot/config.py
+++ b/bot/config.py
@@ -13,6 +13,8 @@ def _is_member(string: str, group: set) -> bool:
 # Discord roles which are allowed full access to bot commands
 _gm_roles: set[str] = {
     "admin",
+    "moderator",
+    "moderators",
     "gm",
     "heavenly angel",
     "emergency gm",

--- a/bot/perms.py
+++ b/bot/perms.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 from discord.ext import commands
 
+from bot.bot import impdip_server
 from bot.utils import is_gm, is_gm_channel, get_player_by_role, is_moderator, is_player_channel, get_player_by_channel, is_admin
 from diplomacy.persistence.manager import Manager
 from diplomacy.persistence.player import Player
@@ -64,8 +65,16 @@ def player(description: str = "run this command"):
 
 
 def assert_mod_only(ctx: commands.Context, description: str = "run this command") -> bool:
-    if not is_moderator(ctx.message.author):
-        raise CommandPermissionError(f"You cannot {description} as you are not a moderator")
+    _hub = ctx.bot.fetch_guild(impdip_server)
+    if not _hub:
+        raise RuntimeError("Cannot fetch the Imperial Diplomacy Hub server.")
+
+    _member = _hub.fetch_member(ctx.author.id)
+    if not _member:
+        raise CommandPermissionError(f"You cannot {description} as you are not a member of the Imperial Diplomacy Hub server.")
+
+    if not is_moderator(_member):
+        raise CommandPermissionError(f"You cannot {description} as you are not a moderator on the Imperial Diplomacy Hub server.")
 
     return True
 

--- a/bot/perms.py
+++ b/bot/perms.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 from discord.ext import commands
 
-from bot.utils import is_gm, is_gm_channel, get_player_by_role, is_player_channel, get_player_by_channel, is_admin
+from bot.utils import is_gm, is_gm_channel, get_player_by_role, is_moderator, is_player_channel, get_player_by_channel, is_admin
 from diplomacy.persistence.manager import Manager
 from diplomacy.persistence.player import Player
 
@@ -62,6 +62,15 @@ def player(description: str = "run this command"):
 
     return player_check
 
+
+def assert_mod_only(ctx: commands.Context, description: str = "run this command") -> bool:
+    if not is_moderator(ctx.message.author):
+        raise CommandPermissionError(f"You cannot {description} as you are not a moderator")
+
+    return True
+
+def mod_only(description: str = "run this command"):
+    return commands.check(lambda ctx: assert_mod_only(ctx, description))
 
 def assert_gm_only(ctx: commands.Context, description: str = "run this command", non_gm_alt: str = None):
     if not is_gm(ctx.message.author):

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -59,6 +59,12 @@ def is_admin(author: commands.Context.author) -> bool:
         1352388421003251833,    # Chloe
     ]
 
+def is_moderator(author: commands.Context.author) -> bool:
+    for role in author.roles:
+        if config.is_mod_role(role.name):
+            return True
+
+    return False
 
 def is_gm(author: commands.Context.author) -> bool:
     for role in author.roles:

--- a/diplomacy/persistence/db/database.py
+++ b/diplomacy/persistence/db/database.py
@@ -175,7 +175,6 @@ class _DatabaseConnection:
                 return player_by_name[player_name]
 
             for player_name, location, is_build, is_army in builds_data:
-
                 player = get_player_by_name(player_name)
 
                 if player is None:
@@ -616,7 +615,7 @@ class _DatabaseConnection:
         cursor = self._connection.cursor()
 
         cursor.execute(
-            "INSERT INTO spec_requests (server_id, user_id, role_id) VALUES (?, ?, ?)",
+            "INSERT OR REPLACE INTO spec_requests (server_id, user_id, role_id) VALUES (?, ?, ?)",
             (request.server_id, request.user_id, request.role_id),
         )
 

--- a/diplomacy/persistence/manager.py
+++ b/diplomacy/persistence/manager.py
@@ -49,14 +49,16 @@ class Manager:
 
         return None
 
-    def save_spec_request(self, server_id: int, user_id: int, role_id: int) -> str:
+    def save_spec_request(
+        self, server_id: int, user_id: int, role_id: int, override=False
+    ) -> str:
         # create new list if first time in server
         if server_id not in self._spec_requests:
             self._spec_requests[server_id] = []
 
         obj = SpecRequest(server_id, user_id, role_id)
 
-        if self.get_spec_request(server_id, user_id):
+        if self.get_spec_request(server_id, user_id) and not override:
             return "User has already been accepted for a request in this Server."
 
         self._spec_requests[server_id].append(obj)


### PR DESCRIPTION
Command to list all servers that a user shares with DiploGM, useful for occasions where a user has to be banned from the community. 

First contribution to a mod tool suite of sorts (at least that will be the idea) for which a new permissions decorator has been created.